### PR TITLE
Renaming of SampleApp package name

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdk 32
 
     defaultConfig {
-        applicationId "tech.dojo.pay.sdk"
+        applicationId "tech.dojo.pay.sdksample"
         minSdk 21
         targetSdk 32
         versionCode 1

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tech.dojo.pay.sdk">
+    package="tech.dojo.pay.sdksample">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentActivity.kt
@@ -1,5 +1,6 @@
-package tech.dojo.pay.sdk
+package tech.dojo.pay.sdksample
 
+import tech.dojo.pay.sdk.DojoSdk
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
 
 class CardPaymentActivity : CardPaymentBaseActivity() {

--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentBaseActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentBaseActivity.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk
+package tech.dojo.pay.sdksample
 
 import android.os.Bundle
 import android.view.View
@@ -7,11 +7,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.launch
+import tech.dojo.pay.sdk.DojoSdk
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
-import tech.dojo.pay.sdk.databinding.ActivityCardPaymentBinding
-import tech.dojo.pay.sdk.token.TokenGenerator
+import tech.dojo.pay.sdksample.databinding.ActivityCardPaymentBinding
+import tech.dojo.pay.sdksample.token.TokenGenerator
 
 abstract class CardPaymentBaseActivity : AppCompatActivity() {
 

--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentOldSchoolActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentOldSchoolActivity.kt
@@ -1,6 +1,7 @@
-package tech.dojo.pay.sdk
+package tech.dojo.pay.sdksample
 
 import android.content.Intent
+import tech.dojo.pay.sdk.DojoSdk
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
 
 class CardPaymentOldSchoolActivity : CardPaymentBaseActivity() {

--- a/sample/src/main/java/tech/dojo/pay/sdksample/Cards.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/Cards.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk
+package tech.dojo.pay.sdksample
 
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 

--- a/sample/src/main/java/tech/dojo/pay/sdksample/SampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/SampleActivity.kt
@@ -1,9 +1,10 @@
-package tech.dojo.pay.sdk
+package tech.dojo.pay.sdksample
 
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import tech.dojo.pay.sdksample.R
 
 class SampleActivity : AppCompatActivity() {
 

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/MerchantParams.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/MerchantParams.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk.token
+package tech.dojo.pay.sdksample.token
 
 class MerchantParams(
     val merchantUrl: String,

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/TokenApi.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/TokenApi.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk.token
+package tech.dojo.pay.sdksample.token
 
 import retrofit2.http.Body
 import retrofit2.http.Headers

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/TokenGenerator.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/TokenGenerator.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk.token
+package tech.dojo.pay.sdksample.token
 
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/TokenResponse.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/TokenResponse.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk.token
+package tech.dojo.pay.sdksample.token
 
 class TokenResponse(
     val id: String

--- a/sample/src/test/java/tech/dojo/pay/sdksample/ExampleUnitTest.kt
+++ b/sample/src/test/java/tech/dojo/pay/sdksample/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package tech.dojo.pay.sdk
+package tech.dojo.pay.sdksample
 
 import org.junit.Test
 


### PR DESCRIPTION

**What**
Renamed SampleApp package from `tech.dojo.pay.sdk` to `tech.dojo.pay.sdksample` to cease conflicts between sampleApp and SDK. 
**Why**
Having the same package name for SDK and SampleApp prevents creating a release version that is needed to test GPay with real cards