### PR TITLE
DojoCardPaymentResult -> DojoPaymentResult

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentBaseActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentBaseActivity.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.launch
 import tech.dojo.pay.sdk.DojoSdk
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdksample.databinding.ActivityCardPaymentBinding
 import tech.dojo.pay.sdksample.token.TokenGenerator
 
@@ -22,7 +22,7 @@ abstract class CardPaymentBaseActivity : AppCompatActivity() {
 
     abstract fun onPayClicked(token: String, payload: DojoCardPaymentPayload)
 
-    fun showResult(result: DojoCardPaymentResult) {
+    fun showResult(result: DojoPaymentResult) {
         showDialog(
             title = "Payment result",
             message = "${result.name} (${result.code})"

--- a/sdk/src/main/java/tech/dojo/pay/sdk/DojoPaymentResult.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/DojoPaymentResult.kt
@@ -1,6 +1,6 @@
-package tech.dojo.pay.sdk.card.entities
+package tech.dojo.pay.sdk
 
-enum class DojoCardPaymentResult(val code: Int) {
+enum class DojoPaymentResult(val code: Int) {
     SUCCESSFUL(0),
     AUTHORIZING(3),
     REFERRED(4),
@@ -15,7 +15,7 @@ enum class DojoCardPaymentResult(val code: Int) {
     SDK_INTERNAL_ERROR(7770);
 
     companion object {
-        fun fromCode(code: Int): DojoCardPaymentResult =
+        fun fromCode(code: Int): DojoPaymentResult =
             values().find { it.code == code } ?: SDK_INTERNAL_ERROR
     }
 }

--- a/sdk/src/main/java/tech/dojo/pay/sdk/DojoSdk.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/DojoSdk.kt
@@ -8,7 +8,6 @@ import tech.dojo.pay.sdk.card.DojoCardPaymentHandlerImpl
 import tech.dojo.pay.sdk.card.DojoCardPaymentResultContract
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentParams
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
 
 object DojoSdk {
 
@@ -21,7 +20,7 @@ object DojoSdk {
      */
     fun createCardPaymentHandler(
         activity: ComponentActivity,
-        onResult: (DojoCardPaymentResult) -> Unit
+        onResult: (DojoPaymentResult) -> Unit
     ): DojoCardPaymentHandler = DojoCardPaymentHandlerImpl(activity, onResult)
 
     /**
@@ -44,7 +43,7 @@ object DojoSdk {
      * Parses activity result to DojoCardPaymentResult.
      * If the result was not initiated by card payment, then null will be returned.
      */
-    fun parseCardPaymentResult(requestCode: Int, resultCode: Int, intent: Intent?): DojoCardPaymentResult? {
+    fun parseCardPaymentResult(requestCode: Int, resultCode: Int, intent: Intent?): DojoPaymentResult? {
         if (requestCode != REQUEST_CODE) return null
         return DojoCardPaymentResultContract().parseResult(resultCode, intent)
     }

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentActivity.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentActivity.kt
@@ -7,7 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.commit
 import tech.dojo.pay.sdk.R
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.entities.PaymentResult
 import tech.dojo.pay.sdk.card.entities.ThreeDSParams
 
@@ -42,7 +42,7 @@ internal class DojoCardPaymentActivity : AppCompatActivity() {
         }
     }
 
-    private fun returnResult(result: DojoCardPaymentResult) {
+    private fun returnResult(result: DojoPaymentResult) {
         val data = Intent()
         data.putExtra(DojoCardPaymentResultContract.KEY_RESULT, result)
         setResult(RESULT_OK, data)

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentHandlerImpl.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentHandlerImpl.kt
@@ -3,11 +3,11 @@ package tech.dojo.pay.sdk.card
 import androidx.activity.ComponentActivity
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentParams
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 
 internal class DojoCardPaymentHandlerImpl(
     activity: ComponentActivity,
-    onResult: (DojoCardPaymentResult) -> Unit
+    onResult: (DojoPaymentResult) -> Unit
 ) : DojoCardPaymentHandler {
 
     private val cardPayment = activity.registerForActivityResult(DojoCardPaymentResultContract(), onResult)

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentResultContract.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentResultContract.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentParams
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 
-internal class DojoCardPaymentResultContract : ActivityResultContract<DojoCardPaymentParams, DojoCardPaymentResult>() {
+internal class DojoCardPaymentResultContract : ActivityResultContract<DojoCardPaymentParams, DojoPaymentResult>() {
 
     override fun createIntent(context: Context, input: DojoCardPaymentParams): Intent {
         val intent = Intent(context, DojoCardPaymentActivity::class.java)
@@ -15,11 +15,11 @@ internal class DojoCardPaymentResultContract : ActivityResultContract<DojoCardPa
         return intent
     }
 
-    override fun parseResult(resultCode: Int, intent: Intent?): DojoCardPaymentResult {
+    override fun parseResult(resultCode: Int, intent: Intent?): DojoPaymentResult {
         return if (resultCode == RESULT_OK && intent != null) {
-            intent.getSerializableExtra(KEY_RESULT) as DojoCardPaymentResult
+            intent.getSerializableExtra(KEY_RESULT) as DojoPaymentResult
         } else {
-            DojoCardPaymentResult.DECLINED
+            DojoPaymentResult.DECLINED
         }
     }
 

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentViewModel.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/DojoCardPaymentViewModel.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import tech.dojo.pay.sdk.card.data.CardPaymentRepository
 import tech.dojo.pay.sdk.card.data.entities.DeviceData
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.entities.PaymentResult
 import tech.dojo.pay.sdk.card.entities.ThreeDSParams
 import kotlin.Exception
@@ -33,7 +33,7 @@ internal class DojoCardPaymentViewModel(
                 paymentResult.value = repository.processPayment()
                 canExit = true
             } catch (throwable: Throwable) {
-                paymentResult.value = PaymentResult.Completed(DojoCardPaymentResult.SDK_INTERNAL_ERROR)
+                paymentResult.value = PaymentResult.Completed(DojoPaymentResult.SDK_INTERNAL_ERROR)
             }
         }
     }
@@ -42,7 +42,7 @@ internal class DojoCardPaymentViewModel(
         fingerPrintCapturedEvent.trySend(Unit)
     }
 
-    fun on3DSCompleted(result: DojoCardPaymentResult) {
+    fun on3DSCompleted(result: DojoPaymentResult) {
         paymentResult.postValue(PaymentResult.Completed(result))
     }
 
@@ -51,7 +51,7 @@ internal class DojoCardPaymentViewModel(
             try {
                 threeDsPage.value = repository.fetch3dsPage(params)
             } catch (e: Exception) {
-                paymentResult.value = PaymentResult.Completed(DojoCardPaymentResult.SDK_INTERNAL_ERROR)
+                paymentResult.value = PaymentResult.Completed(DojoPaymentResult.SDK_INTERNAL_ERROR)
             }
         }
     }

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/ThreeDsInterface.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/ThreeDsInterface.kt
@@ -3,10 +3,10 @@ package tech.dojo.pay.sdk.card
 import android.webkit.JavascriptInterface
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 
 internal class ThreeDsInterface(
-    private val onEventCallback: ((DojoCardPaymentResult) -> Unit)
+    private val onEventCallback: ((DojoPaymentResult) -> Unit)
 ) {
 
     @JavascriptInterface
@@ -18,9 +18,9 @@ internal class ThreeDsInterface(
         val statusCode = (result["statusCode"] as? Double)?.toInt()
 
         val paymentResult = if (statusCode != null) {
-            DojoCardPaymentResult.fromCode(statusCode)
+            DojoPaymentResult.fromCode(statusCode)
         } else {
-            DojoCardPaymentResult.SDK_INTERNAL_ERROR
+            DojoPaymentResult.SDK_INTERNAL_ERROR
         }
 
         onEventCallback.invoke(paymentResult)

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/data/CardPaymentRepository.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/data/CardPaymentRepository.kt
@@ -3,7 +3,7 @@ package tech.dojo.pay.sdk.card.data
 import tech.dojo.pay.sdk.card.data.entities.DeviceData
 import tech.dojo.pay.sdk.card.data.entities.PaymentDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.entities.PaymentResult
 import tech.dojo.pay.sdk.card.entities.ThreeDSParams
 
@@ -20,9 +20,9 @@ internal class CardPaymentRepository(
 
     suspend fun processPayment(): PaymentResult {
         val response = api.processPayment(token, paymentDetails)
-        val paymentResult = DojoCardPaymentResult.fromCode(response.statusCode)
+        val paymentResult = DojoPaymentResult.fromCode(response.statusCode)
 
-        return if (paymentResult == DojoCardPaymentResult.AUTHORIZING) {
+        return if (paymentResult == DojoPaymentResult.AUTHORIZING) {
             PaymentResult.ThreeDSRequired(
                 ThreeDSParams(
                     stepUpUrl = requireNotNull(response.stepUpUrl),

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/entities/PaymentResult.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/entities/PaymentResult.kt
@@ -1,8 +1,10 @@
 package tech.dojo.pay.sdk.card.entities
 
+import tech.dojo.pay.sdk.DojoPaymentResult
+
 internal sealed class PaymentResult {
 
-    data class Completed(val value: DojoCardPaymentResult) : PaymentResult()
+    data class Completed(val value: DojoPaymentResult) : PaymentResult()
 
     data class ThreeDSRequired(val params: ThreeDSParams) : PaymentResult()
 }

--- a/sdk/src/test/java/tech/dojo/pay/sdk/card/DojoCardPaymentViewModelTest.kt
+++ b/sdk/src/test/java/tech/dojo/pay/sdk/card/DojoCardPaymentViewModelTest.kt
@@ -20,7 +20,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.data.CardPaymentRepository
 import tech.dojo.pay.sdk.card.data.entities.DeviceData
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.entities.PaymentResult
 import tech.dojo.pay.sdk.card.entities.ThreeDSParams
 import java.lang.IllegalArgumentException
@@ -44,7 +44,7 @@ internal class DojoCardPaymentViewModelTest {
     fun `WHEN device data collection fails THEN sdk internal error is returned`() = runTest {
         whenever(repository.collectDeviceData()).thenThrow(IllegalArgumentException())
         val viewModel = DojoCardPaymentViewModel(repository)
-        val expected = PaymentResult.Completed(DojoCardPaymentResult.SDK_INTERNAL_ERROR)
+        val expected = PaymentResult.Completed(DojoPaymentResult.SDK_INTERNAL_ERROR)
         assertEquals(expected, viewModel.paymentResult.value)
     }
 
@@ -77,7 +77,7 @@ internal class DojoCardPaymentViewModelTest {
     @Test
     fun `WHEN payment processing completes THEN payment result is returned AND user can exit`() = runTest {
         val deviceData = DeviceData("action", "token")
-        val result = PaymentResult.Completed(DojoCardPaymentResult.SUCCESSFUL)
+        val result = PaymentResult.Completed(DojoPaymentResult.SUCCESSFUL)
         whenever(repository.collectDeviceData()).thenReturn(deviceData)
         whenever(repository.processPayment()).thenReturn(result)
         val viewModel = DojoCardPaymentViewModel(repository)

--- a/sdk/src/test/java/tech/dojo/pay/sdk/card/data/CardPaymentRepositoryTest.kt
+++ b/sdk/src/test/java/tech/dojo/pay/sdk/card/data/CardPaymentRepositoryTest.kt
@@ -17,7 +17,7 @@ import tech.dojo.pay.sdk.card.data.entities.PaymentResponse
 import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayload
-import tech.dojo.pay.sdk.card.entities.DojoCardPaymentResult
+import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.entities.DojoShippingDetails
 import tech.dojo.pay.sdk.card.entities.PaymentResult
 import tech.dojo.pay.sdk.card.entities.ThreeDSParams
@@ -66,7 +66,7 @@ internal class CardPaymentRepositoryTest {
 
         whenever(api.processPayment(any(), any())).thenReturn(
             PaymentResponse(
-                statusCode = DojoCardPaymentResult.AUTHORIZING.code,
+                statusCode = DojoPaymentResult.AUTHORIZING.code,
                 stepUpUrl = threeDSParams.stepUpUrl,
                 jwt = threeDSParams.jwt,
                 md = threeDSParams.md
@@ -81,10 +81,10 @@ internal class CardPaymentRepositoryTest {
     @Test
     fun `WHEN result code is not AUTHORIZING THEN completed result is returned`() = runTest {
         whenever(api.processPayment(any(), any())).thenReturn(
-            PaymentResponse(statusCode = DojoCardPaymentResult.SUCCESSFUL.code)
+            PaymentResponse(statusCode = DojoPaymentResult.SUCCESSFUL.code)
         )
         val result = repo.processPayment()
-        val expected = PaymentResult.Completed(DojoCardPaymentResult.SUCCESSFUL)
+        val expected = PaymentResult.Completed(DojoPaymentResult.SUCCESSFUL)
         assertEquals(expected, result)
     }
 


### PR DESCRIPTION
### What
Generalised `DojoCardPaymentResult` into `DojoPaymentResult` so it can be used as a result for any current and future payment providers 

### Why
When I was adding GPay I ran into the problem that the result that SDK gives back is not unified. For GPay I was needed to add a new result type, which may be a bit of a problem if we'll be adding more ways to pay to the SDK (PayPal, Klarna, _Bitcoin_ 🙈)

