### PR TITLE
add support for keystore info from config file

### DIFF
--- a/keystore.properties
+++ b/keystore.properties
@@ -1,0 +1,4 @@
+releaseKeyAlias=
+releaseKeyPassword=
+releaseKeyStore=
+releaseStorePassword=

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,9 @@ plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
 }
-
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+def keystoreProperties = new Properties()
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 android {
     compileSdk 32
 
@@ -16,6 +18,14 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            keyAlias keystoreProperties['releaseKeyAlias']
+            keyPassword keystoreProperties['releaseKeyPassword']
+            storeFile file(rootDir.getCanonicalPath() + '/' + keystoreProperties['releaseKeyStore'])
+            storePassword keystoreProperties['releaseStorePassword']
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
## WHAT 
- add `keystore.properties` to handle keys 