### PR TITLE
remove cardSandbox from core sdk

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentActivity.kt
@@ -20,7 +20,6 @@ class CardPaymentActivity : CardPaymentBaseActivity() {
     }
 
     override fun onSandboxChecked(isChecked: Boolean) {
-        DojoSdk.cardSandbox = isChecked
         DojoSdk.walletSandBox = isChecked
     }
 

--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentBaseActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentBaseActivity.kt
@@ -17,6 +17,7 @@ import tech.dojo.pay.sdk.card.entities.DojoGPayPayload
 import tech.dojo.pay.sdk.card.entities.DojoPaymentIntent
 import tech.dojo.pay.sdk.card.entities.DojoTotalAmount
 import tech.dojo.pay.sdksample.databinding.ActivityCardPaymentBinding
+import tech.dojo.pay.sdksample.token.PaymentIDGenerator
 import tech.dojo.pay.sdksample.token.TokenGenerator
 
 abstract class CardPaymentBaseActivity : AppCompatActivity() {
@@ -147,7 +148,6 @@ abstract class CardPaymentBaseActivity : AppCompatActivity() {
     }
 
     private fun setTokenListener() {
-        DojoSdk.cardSandbox = binding.checkboxSandbox.isChecked
         DojoSdk.walletSandBox = binding.checkboxSandbox.isChecked
 
         binding.checkboxSandbox.setOnCheckedChangeListener { _, isChecked ->
@@ -160,7 +160,7 @@ abstract class CardPaymentBaseActivity : AppCompatActivity() {
             lifecycleScope.launch {
                 showLoading()
                 try {
-                    displayToken(TokenGenerator.generateToken())
+                    displayToken(PaymentIDGenerator.generatePaymentId().clientSessionSecret)
                 } catch (e: Throwable) {
                     showTokenError(e)
                 } finally {

--- a/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentOldSchoolActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/CardPaymentOldSchoolActivity.kt
@@ -9,7 +9,6 @@ import tech.dojo.pay.sdk.card.entities.DojoPaymentIntent
 class CardPaymentOldSchoolActivity : CardPaymentBaseActivity() {
 
     override fun onSandboxChecked(isChecked: Boolean) {
-        DojoSdk.cardSandbox = isChecked
         DojoSdk.walletSandBox = isChecked
     }
 

--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -58,11 +58,11 @@ class UiSdkSampleActivity : AppCompatActivity() {
                 )
             )
         }
-        DojoSDKDropInUI.sandbox = uiSdkSampleBinding.checkboxSandbox.isChecked
+        DojoSDKDropInUI.isWalletSandBox = uiSdkSampleBinding.checkboxSandbox.isChecked
     }
 
     private fun setTokenListener() {
-        DojoSDKDropInUI.sandbox = uiSdkSampleBinding.checkboxSandbox.isChecked
+        DojoSDKDropInUI.isWalletSandBox = uiSdkSampleBinding.checkboxSandbox.isChecked
 
         uiSdkSampleBinding.checkboxSandbox.setOnCheckedChangeListener { _, isChecked ->
             uiSdkSampleBinding.btnGenerateToken.visibility =
@@ -75,7 +75,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
             lifecycleScope.launch {
                 showLoading()
                 try {
-                    displayToken(PaymentIDGenerator.generatePaymentId())
+                    displayToken(PaymentIDGenerator.generatePaymentId().id)
                 } catch (e: Throwable) {
                     showTokenError(e)
                 } finally {
@@ -91,7 +91,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
     }
 
     private fun onSandboxChecked(isChecked: Boolean) {
-        DojoSDKDropInUI.sandbox = isChecked
+        DojoSDKDropInUI.isWalletSandBox = isChecked
     }
 
     private fun showLoading() {

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/PaymentIDGenerator.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/PaymentIDGenerator.kt
@@ -12,7 +12,7 @@ object PaymentIDGenerator {
             .create(PaymentIntentApi::class.java)
     }
 
-    suspend fun generatePaymentId(): String = paymentIntentApi.getToken(
+    suspend fun generatePaymentId(): PaymentIdResponse = paymentIntentApi.getToken(
         PaymentIdBody(
             amount = Amount(
                 value = 10L,
@@ -48,5 +48,5 @@ object PaymentIDGenerator {
             reference = "Order 234",
             description = "Demo payment intent"
         )
-    ).id
+    )
 }

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/PaymentIdRequest.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/PaymentIdRequest.kt
@@ -14,7 +14,8 @@ data class Amount(
 )
 
 data class PaymentIdResponse(
-    val id: String
+    val id: String,
+    val clientSessionSecret:String
 )
 
 data class ItemLines(

--- a/sample/src/main/java/tech/dojo/pay/sdksample/token/PaymentIntentApi.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/token/PaymentIntentApi.kt
@@ -8,7 +8,7 @@ interface PaymentIntentApi {
 
     @Headers(
         "Authorization:Basic sk_sandbox_b-pGLxFNm_kEr1aEWZcFp9HQu11wey7ucc48Y1e4-nZdGxhAJY3Bgx2Eb_C-itA16bSnojrZKesvnoZAoiRtPA",
-        "Version: 2022-02-07",
+        "Version: 2022-10-18",
         "Content-Type:application/json"
     )
     @POST("payment-intents")

--- a/sdk/src/main/java/tech/dojo/pay/sdk/DojoSdk.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/DojoSdk.kt
@@ -28,7 +28,6 @@ object DojoSdk {
     private val REQUEST_CODE_CARD = "DOJO_PAY".hashCode()
     private val REQUEST_CODE_G_PAY = "DOJO_G_PAY".hashCode()
 
-    var cardSandbox: Boolean = false
     var walletSandBox: Boolean = false
 
     /**

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/data/remote/cardpayment/CardPaymentApiBuilder.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/data/remote/cardpayment/CardPaymentApiBuilder.kt
@@ -6,24 +6,21 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import java.util.concurrent.TimeUnit
 
-internal class CardPaymentApiBuilder(
-    private val sandboxMode: Boolean
-) {
+internal class CardPaymentApiBuilder {
 
     fun create(): CardPaymentApi =
         createRetrofit().create(CardPaymentApi::class.java)
 
     private fun createRetrofit(): Retrofit =
         Retrofit.Builder()
-            .baseUrl(getBaseUrl(sandboxMode))
+            .baseUrl(getBaseUrl())
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(GsonConverterFactory.create())
             .client(createHttpClient())
             .build()
 
-    private fun getBaseUrl(sandboxMode: Boolean): String {
-        val extaPart = if (sandboxMode) "test." else ""
-        return "https://web.e.${extaPart}connect.paymentsense.cloud/api/"
+    private fun getBaseUrl(): String {
+        return "https://web.e.connect.paymentsense.cloud/api/"
     }
 
     private fun createHttpClient(): OkHttpClient =

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/presentation/card/viewmodel/DojoCardPaymentViewModelFactory.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/presentation/card/viewmodel/DojoCardPaymentViewModelFactory.kt
@@ -19,7 +19,7 @@ internal class DojoCardPaymentViewModelFactory(
         val args = requireNotNull(arguments)
         val params =
             args.getSerializable(DojoCardPaymentResultContract.KEY_PARAMS) as DojoCardPaymentParams
-        val api = CardPaymentApiBuilder(DojoSdk.cardSandbox).create()
+        val api = CardPaymentApiBuilder().create()
         val repo = CardPaymentRepository(api, params.token, params.paymentPayload)
         val dojo3DSRepository = Dojo3DSRepository(api)
         return DojoCardPaymentViewModel(repo, dojo3DSRepository) as T

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/presentation/gpay/viewmodel/DojoGPayViewModelFactory.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/presentation/gpay/viewmodel/DojoGPayViewModelFactory.kt
@@ -21,7 +21,7 @@ internal class DojoGPayViewModelFactory(
         val args = requireNotNull(arguments)
         val params =
             args.getSerializable(DojoCardPaymentResultContract.KEY_PARAMS) as DojoGPayParams
-        val api = CardPaymentApiBuilder(DojoSdk.cardSandbox).create()
+        val api = CardPaymentApiBuilder().create()
         val repo = GPayRepository(api, params.dojoPaymentIntent.token)
         val dojo3DSRepository = Dojo3DSRepository(api)
         val mapper = GpayPaymentRequestMapper(Gson())

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/DojoSDKDropInUI.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/DojoSDKDropInUI.kt
@@ -7,7 +7,7 @@ import tech.dojo.pay.uisdk.presentation.handler.DojoPaymentFlowHandler
 import tech.dojo.pay.uisdk.presentation.handler.DojoPaymentFlowHandlerImp
 
 object DojoSDKDropInUI {
-    var sandbox: Boolean = false
+    var isWalletSandBox: Boolean = false
     var dojoThemeSettings: DojoThemeSettings? = null
 
     /**

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -86,8 +86,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
     }
 
     private fun configureDojoPayCore() {
-        DojoSdk.cardSandbox = false
-        DojoSdk.walletSandBox = DojoSDKDropInUI.sandbox
+        DojoSdk.walletSandBox = DojoSDKDropInUI.isWalletSandBox
         gpayPaymentHandler = DojoSdk.createGPayHandler(this) {
             viewModel.updatePaymentState(false)
             viewModel.navigateToPaymentResult(it)


### PR DESCRIPTION
## What
- remove the sandbox logic for card payments flow as the back end will decide  the environment based on the `token`
- keep the `walletSandBox` in both core and UI SDK to switch environments for Gpay  
