### PR TITLE
add loading state when user clicks on pay with gpay

### DIFF
--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/PaymentStateRepository.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/PaymentStateRepository.kt
@@ -5,10 +5,15 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class PaymentStateRepository {
 
     private var isPaymentInProgress: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    private var isGpayPaymentInProgress: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     fun updatePayment(isActive: Boolean) {
         isPaymentInProgress.tryEmit(isActive)
     }
 
+    fun updateGpayPayment(isActive: Boolean) {
+        isGpayPaymentInProgress.tryEmit(isActive)
+    }
     fun observePaymentIntent() = isPaymentInProgress
+    fun observeGpayPaymentIntent() = isGpayPaymentInProgress
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/ObservePaymentStatus.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/ObservePaymentStatus.kt
@@ -6,4 +6,7 @@ class ObservePaymentStatus(
     private val paymentStateRepository: PaymentStateRepository
 ) {
     fun observePaymentStates() = paymentStateRepository.observePaymentIntent()
+
+    fun observeGpayPaymentStates() = paymentStateRepository.observeGpayPaymentIntent()
+
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/UpdatePaymentStateUseCase.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/UpdatePaymentStateUseCase.kt
@@ -8,4 +8,8 @@ class UpdatePaymentStateUseCase(
     fun updatePaymentSate(isActive: Boolean) {
         paymentStateRepository.updatePayment(isActive)
     }
+
+    fun updateGpayPaymentSate(isActive: Boolean) {
+        paymentStateRepository.updateGpayPayment(isActive)
+    }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -112,7 +112,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
     private fun configureDojoPayCore() {
         DojoSdk.walletSandBox = DojoSDKDropInUI.isWalletSandBox
         gpayPaymentHandler = DojoSdk.createGPayHandler(this) {
-            viewModel.updatePaymentState(false)
+            viewModel.updateGpayPaymentState(false)
             viewModel.navigateToPaymentResult(it)
         }
         cardPaymentHandler = DojoSdk.createCardPaymentHandler(this) {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -52,7 +52,9 @@ internal class PaymentFlowViewModel(
     fun updatePaymentState(isActivity: Boolean) {
         updatePaymentStateUseCase.updatePaymentSate(isActivity)
     }
-
+    fun updateGpayPaymentState(isActivity: Boolean) {
+        updatePaymentStateUseCase.updateGpayPaymentSate(isActivity)
+    }
     private fun closeFLowWithInternalError() {
         navigationEvent.value = PaymentFlowNavigationEvents.CLoseFlowWithInternalError
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/paymentmethodcheckout/PaymentMethodsSheet.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/paymentmethodcheckout/PaymentMethodsSheet.kt
@@ -163,7 +163,6 @@ private fun BottomSheetItems(
                 GooglePayButton(
                     contentState,
                     coroutineScope,
-                    sheetState,
                     onGpayClicked,
                     observePaymentIntent
                 )
@@ -265,7 +264,6 @@ private fun Loading() {
 private fun GooglePayButton(
     googlePayVisibility: PaymentMethodCheckoutState,
     coroutineScope: CoroutineScope,
-    sheetState: ModalBottomSheetState,
     onGpayClicked: () -> Unit,
     observePaymentIntent: () -> Unit
 ) {
@@ -277,7 +275,6 @@ private fun GooglePayButton(
         ) {
             coroutineScope.launch {
                 observePaymentIntent()
-                sheetState.hide()
                 onGpayClicked()
             }
         }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -138,6 +138,43 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
+    fun `calling updateGpayPaymentState should call updateGpayPaymentSate from updatePaymentStateUseCase`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP"
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        customerId = "customerId"
+                    )
+                )
+            )
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase
+            )
+            viewModel.updateGpayPaymentState(isActivity = false)
+            // assert
+            verify(updatePaymentStateUseCase).updateGpayPaymentSate(false)
+        }
+
+    @Test
     fun `calling onBackClicked should emits OnBack`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =


### PR DESCRIPTION
## what 
- add loading state  on the gpay flow as we make some requests after we got a response to the gpay SDK
## how 
- add a new stream for the gapy payment process state and listen to it in the "PaymentMethodsCheckOutScreen"
## vid 

https://user-images.githubusercontent.com/71371440/220683511-011de3ec-1797-4226-b581-894104d2f3c8.mp4

