### PR TITLE
- make the core SDK supports card on file by adding new way for fetchng the card of files paymentIntent

### DIFF
--- a/sdk/src/main/java/tech/dojo/pay/sdk/DojoSdk.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/DojoSdk.kt
@@ -35,7 +35,7 @@ object DojoSdk {
      */
     fun createCardPaymentHandler(
         activity: ComponentActivity,
-        onResult: (DojoPaymentResult) -> Unit
+        onResult: (DojoPaymentResult) -> Unit,
     ): DojoCardPaymentHandler = DojoCardPaymentHandlerImpl(activity, onResult)
 
     /**
@@ -43,7 +43,7 @@ object DojoSdk {
      */
     fun createSavedCardPaymentHandler(
         activity: ComponentActivity,
-        onResult: (DojoPaymentResult) -> Unit
+        onResult: (DojoPaymentResult) -> Unit,
     ): DojoSavedCardPaymentHandler = DojoSavedCardPaymentHandlerImpl(activity, onResult)
 
     /**
@@ -52,7 +52,7 @@ object DojoSdk {
 
     fun createVirtualTerminalPaymentHandler(
         activity: ComponentActivity,
-        onResult: (DojoPaymentResult) -> Unit
+        onResult: (DojoPaymentResult) -> Unit,
     ): DojoVirtualTerminalHandlerImp = DojoVirtualTerminalHandlerImp(activity, onResult)
 
     /**
@@ -60,7 +60,7 @@ object DojoSdk {
      */
     fun createGPayHandler(
         activity: ComponentActivity,
-        onResult: (DojoPaymentResult) -> Unit
+        onResult: (DojoPaymentResult) -> Unit,
     ): DojoGPayHandler = DojoGPayHandlerImpl(activity, onResult)
 
     /**
@@ -71,11 +71,11 @@ object DojoSdk {
     fun startCardPayment(
         activity: Activity,
         token: String,
-        payload: FullCardPaymentPayload
+        payload: FullCardPaymentPayload,
     ) {
         val intent = DojoCardPaymentResultContract().createIntent(
             activity,
-            DojoCardPaymentParams(token, payload)
+            DojoCardPaymentParams(token, payload),
         )
         activity.startActivityForResult(intent, REQUEST_CODE_CARD)
     }
@@ -88,11 +88,11 @@ object DojoSdk {
     fun startSavedCardPayment(
         activity: Activity,
         token: String,
-        payload: SavedCardPaymentPayLoad
+        payload: SavedCardPaymentPayLoad,
     ) {
         val intent = DojoCardPaymentResultContract().createIntent(
             activity,
-            DojoCardPaymentParams(token, payload)
+            DojoCardPaymentParams(token, payload),
         )
         activity.startActivityForResult(intent, REQUEST_CODE_SAVED_CARD)
     }
@@ -105,12 +105,12 @@ object DojoSdk {
     fun startGPay(
         activity: Activity,
         GPayPayload: DojoGPayPayload,
-        paymentIntent: DojoPaymentIntent
+        paymentIntent: DojoPaymentIntent,
 
     ) {
         val intent = DojoGPayResultContract().createIntent(
             activity,
-            DojoGPayParams(GPayPayload, paymentIntent)
+            DojoGPayParams(GPayPayload, paymentIntent),
         )
         activity.startActivityForResult(intent, REQUEST_CODE_G_PAY)
     }
@@ -122,7 +122,7 @@ object DojoSdk {
         activity: Activity,
         dojoGPayConfig: DojoGPayConfig,
         onGpayAvailable: () -> Unit,
-        onGpayUnavailable: () -> Unit
+        onGpayUnavailable: () -> Unit,
     ) {
         DojoGPayEngine(activity)
             .isReadyToPay(dojoGPayConfig, { onGpayAvailable() }, { onGpayUnavailable() })
@@ -135,7 +135,7 @@ object DojoSdk {
     fun parseGPayPaymentResult(
         requestCode: Int,
         resultCode: Int,
-        intent: Intent?
+        intent: Intent?,
     ): DojoPaymentResult? {
         if (requestCode != REQUEST_CODE_G_PAY) return null
         return DojoGPayResultContract().parseResult(resultCode, intent)
@@ -148,7 +148,7 @@ object DojoSdk {
     fun parseCardPaymentResult(
         requestCode: Int,
         resultCode: Int,
-        intent: Intent?
+        intent: Intent?,
     ): DojoPaymentResult? {
         if (requestCode != REQUEST_CODE_CARD) return null
         return DojoCardPaymentResultContract().parseResult(resultCode, intent)
@@ -161,7 +161,7 @@ object DojoSdk {
     fun parseSavedCardPaymentResult(
         requestCode: Int,
         resultCode: Int,
-        intent: Intent?
+        intent: Intent?,
     ): DojoPaymentResult? {
         if (requestCode != REQUEST_CODE_SAVED_CARD) return null
         return DojoCardPaymentResultContract().parseResult(resultCode, intent)
@@ -173,10 +173,22 @@ object DojoSdk {
     fun fetchPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
-        onPaymentIntentFailed: () -> Unit
+        onPaymentIntentFailed: () -> Unit,
     ) {
         PaymentIntentProvider()
             .fetchPaymentIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
+    }
+
+    /**
+     * fetch setUp payment intent object in format of json for specific payment id
+     */
+    fun fetchSetUpIntent(
+        paymentId: String,
+        onSetUpIntentSuccess: (paymentIntentJson: String) -> Unit,
+        onSetUpIntentFailed: () -> Unit,
+    ) {
+        PaymentIntentProvider()
+            .fetchSetUpIntent(paymentId, onSetUpIntentSuccess, onSetUpIntentFailed)
     }
 
     /**
@@ -185,7 +197,7 @@ object DojoSdk {
     fun refreshPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
-        onPaymentIntentFailed: () -> Unit
+        onPaymentIntentFailed: () -> Unit,
     ) {
         PaymentIntentProvider()
             .refreshPaymentIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
@@ -199,13 +211,13 @@ object DojoSdk {
         customerId: String,
         customerSecret: String,
         onFetchPaymentMethodsSuccess: (paymentMethodsJson: String) -> Unit,
-        onFetchPaymentMethodsFailed: () -> Unit
+        onFetchPaymentMethodsFailed: () -> Unit,
     ) {
         PaymentMethodsProvider().fetchPaymentMethods(
             customerId,
             customerSecret,
             onFetchPaymentMethodsSuccess,
-            onFetchPaymentMethodsFailed
+            onFetchPaymentMethodsFailed,
         )
     }
 
@@ -218,14 +230,14 @@ object DojoSdk {
         customerSecret: String,
         paymentMethodId: String,
         onDeletePaymentMethodsSuccess: () -> Unit,
-        onDeletePaymentMethodsFailed: () -> Unit
+        onDeletePaymentMethodsFailed: () -> Unit,
     ) {
         PaymentMethodsProvider().deletePaymentMethod(
             customerId,
             customerSecret,
             paymentMethodId,
             onDeletePaymentMethodsSuccess,
-            onDeletePaymentMethodsFailed
+            onDeletePaymentMethodsFailed,
         )
     }
 }

--- a/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/PaymentIntentProvider.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/PaymentIntentProvider.kt
@@ -1,5 +1,6 @@
 package tech.dojo.pay.sdk.payemntintent
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -12,9 +13,10 @@ internal class PaymentIntentProvider(
     private val paymentIntentRepository: PaymentIntentRepository = PaymentIntentRepository(
         PaymentIntentApiBuilder().create(),
     ),
-    private val repositoryScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
 
+    private val repositoryScope: CoroutineScope = CoroutineScope(dispatcher)
     fun fetchPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,

--- a/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/PaymentIntentProvider.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/PaymentIntentProvider.kt
@@ -6,18 +6,21 @@ import kotlinx.coroutines.launch
 import tech.dojo.pay.sdk.DojoPaymentIntentResult
 import tech.dojo.pay.sdk.payemntintent.data.PaymentIntentApiBuilder
 import tech.dojo.pay.sdk.payemntintent.data.PaymentIntentRepository
+
 @Suppress("SwallowedException")
 internal class PaymentIntentProvider(
     private val paymentIntentRepository: PaymentIntentRepository = PaymentIntentRepository(
-        PaymentIntentApiBuilder().create()
-    )
+        PaymentIntentApiBuilder().create(),
+    ),
+    private val repositoryScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
 ) {
+
     fun fetchPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
-        onPaymentIntentFailed: () -> Unit
+        onPaymentIntentFailed: () -> Unit,
     ) {
-        CoroutineScope(Dispatchers.IO).launch {
+        repositoryScope.launch {
             try {
                 when (val result = paymentIntentRepository.getPaymentIntent(paymentId)) {
                     is DojoPaymentIntentResult.Success -> onPaymentIntentSuccess(result.paymentIntentJson)
@@ -29,12 +32,29 @@ internal class PaymentIntentProvider(
         }
     }
 
+    fun fetchSetUpIntent(
+        paymentId: String,
+        onSetUpIntentSuccess: (paymentIntentJson: String) -> Unit,
+        onSetUpIntentFailed: () -> Unit,
+    ) {
+        repositoryScope.launch {
+            try {
+                when (val result = paymentIntentRepository.getSetUpIntent(paymentId)) {
+                    is DojoPaymentIntentResult.Success -> onSetUpIntentSuccess(result.paymentIntentJson)
+                    is DojoPaymentIntentResult.Failed -> onSetUpIntentFailed()
+                }
+            } catch (throwable: Throwable) {
+                onSetUpIntentFailed()
+            }
+        }
+    }
+
     fun refreshPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
-        onPaymentIntentFailed: () -> Unit
+        onPaymentIntentFailed: () -> Unit,
     ) {
-        CoroutineScope(Dispatchers.IO).launch {
+        repositoryScope.launch {
             try {
                 when (val result = paymentIntentRepository.refreshPaymentIntent(paymentId)) {
                     is DojoPaymentIntentResult.Success -> onPaymentIntentSuccess(result.paymentIntentJson)

--- a/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentApi.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentApi.kt
@@ -13,14 +13,21 @@ interface PaymentIntentApi {
     suspend fun fetchPaymentIntent(
         @Path("paymentId") paymentId: String,
         @Header("Version") version: String = API_VERSION,
-        @Header("IS-MOBILE") isMobile: Boolean = true
+        @Header("IS-MOBILE") isMobile: Boolean = true,
+    ): Response<JsonObject>
+
+    @GET("payment-intents/public/{paymentId}")
+    suspend fun fetchSetUpIntent(
+        @Path("paymentId") paymentId: String,
+        @Header("Version") version: String = API_VERSION,
+        @Header("IS-MOBILE") isMobile: Boolean = true,
     ): Response<JsonObject>
 
     @POST("payment-intents/public/{paymentId}/refresh-client-session-secret")
     suspend fun refreshPaymentIntent(
         @Path("paymentId") paymentId: String,
         @Header("Version") version: String = API_VERSION,
-        @Header("IS-MOBILE") isMobile: Boolean = true
+        @Header("IS-MOBILE") isMobile: Boolean = true,
     ): Response<JsonObject>
 }
 

--- a/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentApi.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentApi.kt
@@ -16,7 +16,7 @@ interface PaymentIntentApi {
         @Header("IS-MOBILE") isMobile: Boolean = true,
     ): Response<JsonObject>
 
-    @GET("payment-intents/public/{paymentId}")
+    @GET("setup-intents/public/{paymentId}")
     suspend fun fetchSetUpIntent(
         @Path("paymentId") paymentId: String,
         @Header("Version") version: String = API_VERSION,

--- a/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentRepository.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentRepository.kt
@@ -3,10 +3,19 @@ package tech.dojo.pay.sdk.payemntintent.data
 import tech.dojo.pay.sdk.DojoPaymentIntentResult
 
 internal class PaymentIntentRepository(
-    private val api: PaymentIntentApi
+    private val api: PaymentIntentApi,
 ) {
     suspend fun getPaymentIntent(paymentId: String): DojoPaymentIntentResult {
         val response = api.fetchPaymentIntent(paymentId)
+        return if (response.isSuccessful) {
+            DojoPaymentIntentResult.Success(response.body().toString())
+        } else {
+            DojoPaymentIntentResult.Failed
+        }
+    }
+
+    suspend fun getSetUpIntent(paymentId: String): DojoPaymentIntentResult {
+        val response = api.fetchSetUpIntent(paymentId)
         return if (response.isSuccessful) {
             DojoPaymentIntentResult.Success(response.body().toString())
         } else {

--- a/sdk/src/test/java/tech/dojo/pay/sdk/payemntintent/PaymentIntentProviderTest.kt
+++ b/sdk/src/test/java/tech/dojo/pay/sdk/payemntintent/PaymentIntentProviderTest.kt
@@ -1,0 +1,246 @@
+package tech.dojo.pay.sdk.payemntintent
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import tech.dojo.pay.sdk.DojoPaymentIntentResult
+import tech.dojo.pay.sdk.payemntintent.data.PaymentIntentRepository
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class PaymentIntentProviderTest {
+
+    private val paymentIntentRepository: PaymentIntentRepository = mockk()
+    private val repositoryScope: CoroutineScope = CoroutineScope(UnconfinedTestDispatcher())
+
+    private val paymentIntentProvider = PaymentIntentProvider(
+        paymentIntentRepository,
+        repositoryScope,
+    )
+
+    @Test
+    fun `when fetchPaymentIntent success onPaymentIntentSuccess should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        val paymentIntent = "paymentIntent"
+        var actualPaymentIntentResult = ""
+
+        coEvery {
+            paymentIntentRepository.getPaymentIntent(any())
+        }.answers { DojoPaymentIntentResult.Success(paymentIntent) }
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {
+            actualPaymentIntentResult = paymentIntent
+        }
+        val onPaymentIntentFailed: () -> Unit = {}
+        // act
+        paymentIntentProvider.fetchPaymentIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertEquals(actualPaymentIntentResult, paymentIntent)
+    }
+
+    @Test
+    fun `when fetchPaymentIntent fails onPaymentIntentFailed should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        var actualPaymentIntentResult = ""
+
+        coEvery {
+            paymentIntentRepository.getPaymentIntent(any())
+        }.answers { DojoPaymentIntentResult.Failed }
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {
+            actualPaymentIntentResult = ""
+        }
+        // act
+        paymentIntentProvider.fetchPaymentIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertTrue(actualPaymentIntentResult.isBlank())
+    }
+
+    @Test
+    fun `when fetchPaymentIntent Throws onPaymentIntentFailed should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        var actualPaymentIntentResult = ""
+        val exception = Exception()
+
+        coEvery {
+            paymentIntentRepository.getPaymentIntent(any())
+        }.throws(exception)
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {
+            actualPaymentIntentResult = ""
+        }
+        // act
+        paymentIntentProvider.fetchPaymentIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertTrue(actualPaymentIntentResult.isBlank())
+    }
+
+    @Test
+    fun `when fetchSetUpIntent success onSetUpIntentSuccess should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        val setUpIntent = "setUpIntent"
+        var actualSetUpIntentResult = ""
+
+        coEvery {
+            paymentIntentRepository.getSetUpIntent(any())
+        }.answers { DojoPaymentIntentResult.Success(setUpIntent) }
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {
+            actualSetUpIntentResult = setUpIntent
+        }
+        val onPaymentIntentFailed: () -> Unit = {}
+        // act
+        paymentIntentProvider.fetchSetUpIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertEquals(actualSetUpIntentResult, setUpIntent)
+    }
+
+    @Test
+    fun `when fetchSetUpIntent fails onSetUpIntentFailed should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        var actualSetUpIntentResult = ""
+
+        coEvery {
+            paymentIntentRepository.getSetUpIntent(any())
+        }.answers { DojoPaymentIntentResult.Failed }
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {
+            actualSetUpIntentResult = ""
+        }
+        // act
+        paymentIntentProvider.fetchSetUpIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertTrue(actualSetUpIntentResult.isBlank())
+    }
+
+    @Test
+    fun `when fetchSetUpIntent Throws onSetUpIntentFailed should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        var actualSetUpIntentResult = ""
+        val exception = Exception()
+        coEvery {
+            paymentIntentRepository.getSetUpIntent(any())
+        }.throws(exception)
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {
+            actualSetUpIntentResult = ""
+        }
+        // act
+        paymentIntentProvider.fetchSetUpIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertTrue(actualSetUpIntentResult.isBlank())
+    }
+
+    @Test
+    fun `when refreshPaymentIntent success onPaymentIntentSuccess should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        val paymentIntent = "paymentIntent"
+        var actualPaymentIntentResult = ""
+
+        coEvery {
+            paymentIntentRepository.refreshPaymentIntent(any())
+        }.answers { DojoPaymentIntentResult.Success(paymentIntent) }
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {
+            actualPaymentIntentResult = paymentIntent
+        }
+        val onPaymentIntentFailed: () -> Unit = {}
+        // act
+        paymentIntentProvider.refreshPaymentIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertEquals(actualPaymentIntentResult, paymentIntent)
+    }
+
+    @Test
+    fun `when refreshPaymentIntent fails onPaymentIntentFailed should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        var actualPaymentIntentResult = ""
+
+        coEvery {
+            paymentIntentRepository.refreshPaymentIntent(any())
+        }.answers { DojoPaymentIntentResult.Failed }
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {
+            actualPaymentIntentResult = ""
+        }
+        // act
+        paymentIntentProvider.refreshPaymentIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertTrue(actualPaymentIntentResult.isBlank())
+    }
+
+    @Test
+    fun `when refreshPaymentIntent Throws onPaymentIntentFailed should be invoked`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        var actualPaymentIntentResult = ""
+        val exception = Exception()
+
+        coEvery {
+            paymentIntentRepository.refreshPaymentIntent(any())
+        }.throws(exception)
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {
+            actualPaymentIntentResult = ""
+        }
+        // act
+        paymentIntentProvider.refreshPaymentIntent(
+            paymentId,
+            onPaymentIntentSuccess,
+            onPaymentIntentFailed,
+        )
+
+        // assert
+        assertTrue(actualPaymentIntentResult.isBlank())
+    }
+}

--- a/sdk/src/test/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentRepositoryTest.kt
+++ b/sdk/src/test/java/tech/dojo/pay/sdk/payemntintent/data/PaymentIntentRepositoryTest.kt
@@ -52,6 +52,37 @@ class PaymentIntentRepositoryTest {
         }
 
     @Test
+    fun `calling getSetUpIntent with Successful response should return Success DojoPaymentIntentResult `() =
+        runTest {
+            // arrange
+            val result = JsonObject()
+            result.addProperty("test_key", "test")
+            val response: Response<JsonObject> = mock()
+            whenever(response.isSuccessful).thenReturn(true)
+            whenever(response.body()).thenReturn(result)
+            whenever(api.fetchSetUpIntent(any(), any(), any())).thenReturn(response)
+            val expected = DojoPaymentIntentResult.Success("{\"test_key\":\"test\"}")
+            // act
+            val actual = PaymentIntentRepository(api).getSetUpIntent("test")
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `calling getSetUpIntent with Failed response should return Failed DojoPaymentIntentResult `() =
+        runTest {
+            // arrange
+            val response: Response<JsonObject> = mock()
+            whenever(response.isSuccessful).thenReturn(false)
+            whenever(api.fetchSetUpIntent(any(), any(), any())).thenReturn(response)
+            val expected = DojoPaymentIntentResult.Failed
+            // act
+            val actual = PaymentIntentRepository(api).getSetUpIntent("test")
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
+
+    @Test
     fun `calling refreshPaymentIntent with Successful response should return Success DojoPaymentIntentResult `() =
         runTest {
             // arrange


### PR DESCRIPTION
## what 
- make the core SDK support fetching new type of payment intents which is the Card on file 
## How 
- add new API to `PaymentIntentApi` and`PaymentIntentRepository` along with`PaymentIntentProvider`
- expose new method for the SDK wrapper to fetch that type of payment intent 
-  update unit tests and add the missing once 