### PR TITLE
[rmcx-2732] - add new method to start payment flow for setup intent for UI sdk

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -13,6 +13,7 @@ import tech.dojo.pay.sdksample.databinding.ActivityUiSdkSampleBinding
 import tech.dojo.pay.sdksample.token.PaymentIDGenerator
 import tech.dojo.pay.uisdk.DojoSDKDropInUI
 import tech.dojo.pay.uisdk.entities.DojoPaymentFlowParams
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 import tech.dojo.pay.uisdk.entities.DojoThemeSettings
 
 class UiSdkSampleActivity : AppCompatActivity() {
@@ -32,7 +33,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
         uiSdkSampleBinding.startPaymentFlow.setOnClickListener {
             DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = false)
             dojoPayUI.startPaymentFlow(
-                DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString())
+                DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),
             )
         }
         uiSdkSampleBinding.startPaymentFlowWithTheme.setOnClickListener {
@@ -44,10 +45,10 @@ class UiSdkSampleActivity : AppCompatActivity() {
                     GPayConfig = DojoGPayConfig(
                         merchantName = "Dojo Cafe (Paymentsense)",
                         merchantId = "BCR2DN6T57R5ZI34",
-                        gatewayMerchantId = "119784244252745"
+                        gatewayMerchantId = "119784244252745",
                     ),
-                    isVirtualTerminalPayment = true
-                )
+                    paymentType = DojoPaymentType.VIRTUAL_TERMINAL,
+                ),
             )
         }
     }
@@ -122,7 +123,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
     private fun showResult(result: DojoPaymentResult) {
         showDialog(
             title = "Payment result",
-            message = "${result.name} (${result.code})"
+            message = "${result.name} (${result.code})",
         )
         displayToken("")
         displayCustomerSecrete("")

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentDataSource.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentDataSource.kt
@@ -6,14 +6,22 @@ class PaymentIntentDataSource {
     fun fetchPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
-        onPaymentIntentFailed: () -> Unit
+        onPaymentIntentFailed: () -> Unit,
     ) {
         DojoSdk.fetchPaymentIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
+    }
+
+    fun fetchSetUpIntent(
+        paymentId: String,
+        onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
+        onPaymentIntentFailed: () -> Unit,
+    ) {
+        DojoSdk.fetchSetUpIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
     }
     fun refreshPaymentIntent(
         paymentId: String,
         onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit,
-        onPaymentIntentFailed: () -> Unit
+        onPaymentIntentFailed: () -> Unit,
     ) {
         DojoSdk.refreshPaymentIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentRepository.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentRepository.kt
@@ -11,7 +11,7 @@ import tech.dojo.pay.uisdk.domain.mapper.PaymentIntentDomainEntityMapper
 internal class PaymentIntentRepository(
     private val dataSource: PaymentIntentDataSource = PaymentIntentDataSource(),
     private val gson: Gson = Gson(),
-    private val mapper: PaymentIntentDomainEntityMapper = PaymentIntentDomainEntityMapper()
+    private val mapper: PaymentIntentDomainEntityMapper = PaymentIntentDomainEntityMapper(),
 ) {
     private lateinit var paymentIntentResult: MutableStateFlow<PaymentIntentResult?>
 
@@ -20,16 +20,24 @@ internal class PaymentIntentRepository(
         dataSource.fetchPaymentIntent(
             paymentId,
             { handleSuccessPaymentIntent(it) },
-            { paymentIntentResult.tryEmit(PaymentIntentResult.FetchFailure) }
+            { paymentIntentResult.tryEmit(PaymentIntentResult.FetchFailure) },
         )
     }
 
+    fun fetchSetUpIntent(paymentId: String) {
+        paymentIntentResult = MutableStateFlow(null)
+        dataSource.fetchSetUpIntent(
+            paymentId,
+            { handleSuccessPaymentIntent(it) },
+            { paymentIntentResult.tryEmit(PaymentIntentResult.FetchFailure) },
+        )
+    }
     fun refreshPaymentIntent(paymentId: String) {
         paymentIntentResult = MutableStateFlow(null)
         dataSource.refreshPaymentIntent(
             paymentId,
             { handleSuccessRefresh(it) },
-            { paymentIntentResult.tryEmit(PaymentIntentResult.RefreshFailure) }
+            { paymentIntentResult.tryEmit(PaymentIntentResult.RefreshFailure) },
         )
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCase.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCase.kt
@@ -1,11 +1,23 @@
 package tech.dojo.pay.uisdk.domain
 
 import tech.dojo.pay.uisdk.data.paymentintent.PaymentIntentRepository
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 
 internal class FetchPaymentIntentUseCase(
-    private val repo: PaymentIntentRepository
+    private val repo: PaymentIntentRepository,
 ) {
-    fun fetchPaymentIntent(paymentId: String) {
+    fun fetchPaymentIntentWithPaymentType(paymentType: DojoPaymentType, paymentId: String) {
+        when (paymentType) {
+            DojoPaymentType.PAYMENT_CARD -> fetchPaymentIntent(paymentId)
+            DojoPaymentType.VIRTUAL_TERMINAL -> fetchPaymentIntent(paymentId)
+            DojoPaymentType.CARD_ON_FILE -> fetchSetUpIntent(paymentId)
+        }
+    }
+    private fun fetchPaymentIntent(paymentId: String) {
         repo.fetchPaymentIntent(paymentId)
+    }
+
+    private fun fetchSetUpIntent(paymentId: String) {
+        repo.fetchSetUpIntent(paymentId)
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCase.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCase.kt
@@ -1,14 +1,26 @@
 package tech.dojo.pay.uisdk.domain
 
 import tech.dojo.pay.uisdk.data.paymentmethods.PaymentMethodsRepository
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 
 internal class FetchPaymentMethodsUseCase(
-    private val repo: PaymentMethodsRepository
+    private val repo: PaymentMethodsRepository,
 ) {
-    fun fetchPaymentMethods(customerId: String, customerSecret: String) {
+
+    fun fetchPaymentMethodsWithPaymentType(
+        paymentType: DojoPaymentType,
+        customerId: String,
+        customerSecret: String,
+    ) {
+        if (paymentType != DojoPaymentType.CARD_ON_FILE) {
+            fetchPaymentMethods(customerId, customerSecret)
+        }
+    }
+
+    private fun fetchPaymentMethods(customerId: String, customerSecret: String) {
         repo.fetchPaymentMethod(
             customerId,
-            customerSecret
+            customerSecret,
         )
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoPaymentFlowParams.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoPaymentFlowParams.kt
@@ -6,5 +6,5 @@ data class DojoPaymentFlowParams @JvmOverloads constructor(
     val paymentId: String,
     val clientSecret: String? = null,
     val GPayConfig: DojoGPayConfig? = null,
-    val isVirtualTerminalPayment: Boolean? = false
+    val paymentType: DojoPaymentType = DojoPaymentType.PAYMENT_CARD,
 ) : Serializable

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoPaymentType.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoPaymentType.kt
@@ -1,0 +1,9 @@
+package tech.dojo.pay.uisdk.entities
+
+import java.io.Serializable
+
+enum class DojoPaymentType : Serializable {
+    PAYMENT_CARD,
+    CARD_ON_FILE,
+    VIRTUAL_TERMINAL,
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
@@ -5,9 +5,9 @@ import java.io.Serializable
 
 data class DojoThemeSettings @JvmOverloads constructor(
     val lightColorPalette: LightColorPalette = LightColorPalette(),
-    val DarkColorPalette: DarkColorPalette = DarkColorPalette(),
+    val darkColorPalette: DarkColorPalette = DarkColorPalette(),
     val forceLightMode: Boolean = false,
-    val showBranding: Boolean = true
+    val showBranding: Boolean = true,
 ) : Serializable
 
 data class LightColorPalette @JvmOverloads constructor(
@@ -30,7 +30,7 @@ data class LightColorPalette @JvmOverloads constructor(
     val inputFieldDefaultBorderColor: String = "#26000000",
     val inputFieldSelectedBorderColor: String = "#FF00857D",
     val inputElementActiveTintColor: String = "#FF00857D",
-    val inputElementDefaultTintColor: String = "#26000000"
+    val inputElementDefaultTintColor: String = "#26000000",
 ) : Serializable
 
 data class DarkColorPalette @JvmOverloads constructor(
@@ -53,7 +53,7 @@ data class DarkColorPalette @JvmOverloads constructor(
     val inputFieldDefaultBorderColor: String = "#26FFFFFF",
     val inputFieldSelectedBorderColor: String = "#FFFFFFFF",
     val inputElementActiveTintColor: String = "#FFFFFFFF",
-    val inputElementDefaultTintColor: String = "#FFFFFFFF"
+    val inputElementDefaultTintColor: String = "#FFFFFFFF",
 ) : Serializable
 
 internal val String.color

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -303,15 +303,11 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 CardDetailsCheckoutViewModelFactory(
                     cardPaymentHandler,
                     isDarkModeEnabled,
-                    virtualTerminalHandler,
                     this@PaymentFlowContainerActivity,
                 )
             }
             // this is to handle unregistered activity when screen orientation change
-            cardDetailsCheckoutViewModel.updateCardPaymentHandler(
-                cardPaymentHandler,
-                virtualTerminalHandler,
-            )
+            cardDetailsCheckoutViewModel.updateCardPaymentHandler(cardPaymentHandler)
             AnimatedVisibility(
                 visible = true,
                 enter = expandVertically(),

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -39,6 +39,8 @@ import tech.dojo.pay.uisdk.presentation.components.rememberWindowSize
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.components.theme.LocalDojoColors
 import tech.dojo.pay.uisdk.presentation.contract.DojoPaymentFlowHandlerResultContract
+import tech.dojo.pay.uisdk.presentation.navigation.CUSTOMER_ID_PARAMS_KEY
+import tech.dojo.pay.uisdk.presentation.navigation.DOJO_PAYMENT_RESULT_PARAMS_KEY
 import tech.dojo.pay.uisdk.presentation.navigation.PaymentFlowNavigationEvents
 import tech.dojo.pay.uisdk.presentation.navigation.PaymentFlowScreens
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.CardDetailsCheckoutScreen
@@ -253,7 +255,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         composable(
             route = PaymentFlowScreens.ManagePaymentMethods.route,
             arguments = listOf(
-                navArgument(name = "customerId") {
+                navArgument(name = CUSTOMER_ID_PARAMS_KEY) {
                     type = NavType.StringType
                     defaultValue = ""
                     nullable = true
@@ -265,7 +267,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 enter = expandVertically(),
                 exit = shrinkVertically(),
             ) {
-                val customerId = it.arguments?.get("customerId") as String
+                val customerId = it.arguments?.getString(CUSTOMER_ID_PARAMS_KEY) ?: ""
 
                 val mangePaymentViewModel: MangePaymentViewModel by viewModels {
                     MangePaymentViewModelFactory(
@@ -369,14 +371,14 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         composable(
             route = PaymentFlowScreens.PaymentResult.route,
             arguments = listOf(
-                navArgument(name = "dojoPaymentResult") {
+                navArgument(name = DOJO_PAYMENT_RESULT_PARAMS_KEY) {
                     type = NavType.EnumType(DojoPaymentResult::class.java)
                     defaultValue = DojoPaymentResult.DECLINED
                     nullable = false
                 },
             ),
         ) {
-            val result = it.arguments?.get("dojoPaymentResult") as DojoPaymentResult
+            val result = it.arguments?.get(DOJO_PAYMENT_RESULT_PARAMS_KEY) as DojoPaymentResult
             val refreshPaymentIntent =
                 RefreshPaymentIntentUseCase(PaymentFlowViewModelFactory.paymentIntentRepository)
             val observePaymentIntent =
@@ -408,6 +410,6 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         val data = Intent()
         data.putExtra(DojoPaymentFlowHandlerResultContract.KEY_RESULT, result)
         setResult(RESULT_OK, data)
-        overridePendingTransition(0, tech.dojo.pay.sdk.R.anim.exit)
+        overridePendingTransition(200, tech.dojo.pay.sdk.R.anim.exit)
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -233,16 +233,16 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
             paymentMethodCheckoutViewModel.updateSavedCardPaymentHandler(savedCardPaymentHandler)
             paymentMethodCheckoutViewModel.updateGpayHandler(gpayPaymentHandler)
             PaymentMethodsCheckOutScreen(
-                windowSize,
-                currentSelectedMethod,
-                paymentMethodCheckoutViewModel,
-                {
+                windowSize = windowSize,
+                currentSelectedMethod = currentSelectedMethod,
+                viewModel = paymentMethodCheckoutViewModel,
+                onAppBarIconClicked = {
                     returnResult(DojoPaymentResult.DECLINED)
                     viewModel.onCloseFlowClicked()
                 },
-                viewModel::navigateToManagePaymentMethods,
-                viewModel::navigateToCardDetailsCheckoutScreen,
-                showDojoBrand,
+                onManagePaymentClicked = viewModel::navigateToManagePaymentMethods,
+                onPayByCard = viewModel::navigateToCardDetailsCheckoutScreen,
+                showDojoBrand = showDojoBrand,
             )
         }
     }
@@ -278,15 +278,15 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                     )
                 }
                 ManagePaymentMethods(
-                    windowSize,
-                    mangePaymentViewModel,
-                    {
+                    windowSize = windowSize,
+                    viewModel = mangePaymentViewModel,
+                    onCloseClicked = {
                         returnResult(DojoPaymentResult.DECLINED)
                         viewModel.onCloseFlowClicked()
                     },
-                    viewModel::onBackClickedWithSavedPaymentMethod,
-                    viewModel::navigateToCardDetailsCheckoutScreen,
-                    showDojoBrand,
+                    onBackClicked = viewModel::onBackClickedWithSavedPaymentMethod,
+                    onNewCardButtonClicked = viewModel::navigateToCardDetailsCheckoutScreen,
+                    showDojoBrand = showDojoBrand,
                 )
             }
         }
@@ -307,7 +307,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                     this@PaymentFlowContainerActivity,
                 )
             }
-            // this is to  handle unregistered activity when screen orientation change
+            // this is to handle unregistered activity when screen orientation change
             cardDetailsCheckoutViewModel.updateCardPaymentHandler(
                 cardPaymentHandler,
                 virtualTerminalHandler,
@@ -318,15 +318,22 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 exit = shrinkVertically(),
             ) {
                 CardDetailsCheckoutScreen(
-                    windowSize,
-                    cardDetailsCheckoutViewModel,
-                    {
+                    windowSize = windowSize,
+                    viewModel = cardDetailsCheckoutViewModel,
+                    onCloseClicked = {
                         returnResult(DojoPaymentResult.DECLINED)
                         viewModel.onCloseFlowClicked()
                     },
-                    viewModel::onBackClicked,
-                    isDarkModeEnabled,
-                    showDojoBrand,
+                    onBackClicked = {
+                        if (flowStartDestination == PaymentFlowScreens.CardDetailsCheckout) {
+                            returnResult(DojoPaymentResult.DECLINED)
+                            viewModel.onCloseFlowClicked()
+                        } else {
+                            viewModel.onBackClicked()
+                        }
+                    },
+                    isDarkModeEnabled = isDarkModeEnabled,
+                    showDojoBrand = showDojoBrand,
                 )
             }
         }
@@ -347,18 +354,18 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 )
             }
             VirtualTerminalCheckOutScreen(
-                windowSize,
-                virtualMachineErrorViewModel,
-                {
+                windowSize = windowSize,
+                viewModel = virtualMachineErrorViewModel,
+                onCloseClicked = {
                     returnResult(DojoPaymentResult.DECLINED)
                     viewModel.onCloseFlowClicked()
                 },
-                {
+                onBackClicked = {
                     returnResult(DojoPaymentResult.DECLINED)
                     viewModel.onCloseFlowClicked()
                 },
-                isDarkModeEnabled,
-                showDojoBrand,
+                isDarkModeEnabled = isDarkModeEnabled,
+                showDojoBrand = showDojoBrand,
             )
         }
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -75,6 +75,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        configureDojoSDKDebugConfig()
         configureDojoPayCore()
         setContent {
             DojoTheme() {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -38,7 +38,7 @@ internal class PaymentFlowViewModel(
     init {
         viewModelScope.launch {
             try {
-                fetchPaymentIntentUseCase.fetchPaymentIntent(paymentId)
+                fetchPaymentIntentUseCase.fetchPaymentIntentWithPaymentType(paymentType, paymentId)
                 observePaymentIntent.observePaymentIntent().collect {
                     it?.let { paymentIntentResult -> handlePaymentIntentResult(paymentIntentResult, customerSecret) }
                 }
@@ -66,9 +66,11 @@ internal class PaymentFlowViewModel(
     ) {
         if (isSDKInitiatedCorrectly(paymentIntentResult.result)) {
             currentCustomerId = paymentIntentResult.result.customerId
-            fetchPaymentMethodsUseCase.fetchPaymentMethods(
+            fetchPaymentMethodsUseCase.fetchPaymentMethodsWithPaymentType(
+                paymentType,
                 paymentIntentResult.result.customerId ?: "",
                 customerSecret,
+
             )
         } else {
             closeFlowWithInternalError()

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -74,11 +74,11 @@ internal class PaymentFlowViewModel(
         }
     }
 
-    private fun isSDKInitiatedCorrectly(result: PaymentIntentDomainEntity): Boolean {
-        return if (result.isVirtualTerminalPayment && isVirtualTerminalPayment) {
+    private fun isSDKInitiatedCorrectly(paymentIntent: PaymentIntentDomainEntity): Boolean {
+        return if (paymentIntent.isVirtualTerminalPayment && isVirtualTerminalPayment) {
             true
         } else {
-            !result.isVirtualTerminalPayment && !isVirtualTerminalPayment
+            !paymentIntent.isVirtualTerminalPayment && !isVirtualTerminalPayment
         }
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -13,6 +13,7 @@ import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
 import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.entities.DarkColorPalette
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 import tech.dojo.pay.uisdk.entities.LightColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.darkColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.lightColorPalette
@@ -24,7 +25,7 @@ import tech.dojo.pay.uisdk.presentation.ui.mangepaymentmethods.state.PaymentMeth
 internal class PaymentFlowViewModel(
     private val paymentId: String,
     customerSecret: String,
-    private val isVirtualTerminalPayment: Boolean,
+    private val paymentType: DojoPaymentType,
     private val fetchPaymentIntentUseCase: FetchPaymentIntentUseCase,
     private val observePaymentIntent: ObservePaymentIntent,
     private val fetchPaymentMethodsUseCase: FetchPaymentMethodsUseCase,
@@ -75,10 +76,10 @@ internal class PaymentFlowViewModel(
     }
 
     private fun isSDKInitiatedCorrectly(paymentIntent: PaymentIntentDomainEntity): Boolean {
-        return if (paymentIntent.isVirtualTerminalPayment && isVirtualTerminalPayment) {
+        return if (paymentIntent.isVirtualTerminalPayment && paymentType == DojoPaymentType.VIRTUAL_TERMINAL) {
             true
         } else {
-            !paymentIntent.isVirtualTerminalPayment && !isVirtualTerminalPayment
+            !paymentIntent.isVirtualTerminalPayment && paymentType == DojoPaymentType.PAYMENT_CARD
         }
     }
 
@@ -131,7 +132,7 @@ internal class PaymentFlowViewModel(
     }
 
     fun getFlowStartDestination(): PaymentFlowScreens {
-        return if (isVirtualTerminalPayment) {
+        return if (paymentType == DojoPaymentType.VIRTUAL_TERMINAL) {
             PaymentFlowScreens.VirtualTerminalCheckOutScreen
         } else {
             PaymentFlowScreens.PaymentMethodCheckout
@@ -141,7 +142,7 @@ internal class PaymentFlowViewModel(
 
     fun getCustomColorPalette(isDarkModeEnabled: Boolean) = if (isDarkModeEnabled) {
         darkColorPalette(
-            DojoSDKDropInUI.dojoThemeSettings?.DarkColorPalette
+            DojoSDKDropInUI.dojoThemeSettings?.darkColorPalette
                 ?: DarkColorPalette(),
         )
     } else {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -132,10 +132,10 @@ internal class PaymentFlowViewModel(
     }
 
     fun getFlowStartDestination(): PaymentFlowScreens {
-        return if (paymentType == DojoPaymentType.VIRTUAL_TERMINAL) {
-            PaymentFlowScreens.VirtualTerminalCheckOutScreen
-        } else {
-            PaymentFlowScreens.PaymentMethodCheckout
+        return when (paymentType) {
+            DojoPaymentType.PAYMENT_CARD -> PaymentFlowScreens.PaymentMethodCheckout
+            DojoPaymentType.CARD_ON_FILE -> PaymentFlowScreens.CardDetailsCheckout
+            DojoPaymentType.VIRTUAL_TERMINAL -> PaymentFlowScreens.VirtualTerminalCheckOutScreen
         }
     }
     fun isPaymentInSandBoxEnvironment(): Boolean = paymentId.lowercase().contains("sandbox")

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelFactory.kt
@@ -12,6 +12,7 @@ import tech.dojo.pay.uisdk.domain.FetchPaymentMethodsUseCase
 import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
 import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.entities.DojoPaymentFlowParams
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 import tech.dojo.pay.uisdk.presentation.contract.DojoPaymentFlowHandlerResultContract
 
 internal class PaymentFlowViewModelFactory(private val arguments: Bundle?) :
@@ -25,12 +26,12 @@ internal class PaymentFlowViewModelFactory(private val arguments: Bundle?) :
         val customerSecret =
             (arguments?.getSerializable(DojoPaymentFlowHandlerResultContract.KEY_PARAMS) as? DojoPaymentFlowParams)?.clientSecret
                 ?: ""
-        val isVirtualTerminalPayment =
+        val paymentType =
             (
                 arguments?.getSerializable(DojoPaymentFlowHandlerResultContract.KEY_PARAMS) as?
                     DojoPaymentFlowParams
-                )?.isVirtualTerminalPayment
-                ?: false
+                )?.paymentType
+                ?: DojoPaymentType.PAYMENT_CARD
         val fetchPaymentIntentUseCase = FetchPaymentIntentUseCase(paymentIntentRepository)
         val observePaymentIntent = ObservePaymentIntent(paymentIntentRepository)
         val updatePaymentStateUseCase = UpdatePaymentStateUseCase(paymentStatusRepository)
@@ -39,11 +40,11 @@ internal class PaymentFlowViewModelFactory(private val arguments: Bundle?) :
         return PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         ) as T
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/theme/Theme.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/theme/Theme.kt
@@ -48,7 +48,7 @@ internal fun lightColorPalette(lightColorPalette: LightColorPalette = LightColor
         inputFieldDefaultBorderColor = lightColorPalette.inputFieldDefaultBorderColor.color,
         inputFieldSelectedBorderColor = lightColorPalette.inputFieldSelectedBorderColor.color,
         inputElementActiveTintColor = lightColorPalette.inputElementActiveTintColor.color,
-        inputElementDefaultTintColor = lightColorPalette.inputElementDefaultTintColor.color
+        inputElementDefaultTintColor = lightColorPalette.inputElementDefaultTintColor.color,
     )
 
 internal fun darkColorPalette(darkColorPalette: DarkColorPalette = DarkColorPalette()) = DojoColors(
@@ -82,13 +82,13 @@ internal fun darkColorPalette(darkColorPalette: DarkColorPalette = DarkColorPale
     inputFieldDefaultBorderColor = darkColorPalette.inputFieldDefaultBorderColor.color,
     inputFieldSelectedBorderColor = darkColorPalette.inputFieldSelectedBorderColor.color,
     inputElementActiveTintColor = darkColorPalette.inputElementActiveTintColor.color,
-    inputElementDefaultTintColor = darkColorPalette.inputElementDefaultTintColor.color
+    inputElementDefaultTintColor = darkColorPalette.inputElementDefaultTintColor.color,
 )
 
 @Composable
 fun DojoTheme(
     darkTheme: Boolean = false,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     val colors = if (darkTheme) darkColorPalette() else lightColorPalette()
 
@@ -96,7 +96,7 @@ fun DojoTheme(
         MaterialTheme(
             colors = materialColors(colors, darkTheme),
             typography = DojoTypography,
-            content = content
+            content = content,
         )
     }
 }
@@ -148,7 +148,7 @@ class DojoColors(
     inputFieldDefaultBorderColor: Color,
     inputFieldSelectedBorderColor: Color,
     inputElementActiveTintColor: Color,
-    inputElementDefaultTintColor: Color
+    inputElementDefaultTintColor: Color,
 ) {
     var primary by mutableStateOf(primary)
         private set
@@ -183,13 +183,13 @@ class DojoColors(
     var primarySurfaceBackgroundColor by mutableStateOf(primarySurfaceBackgroundColor)
         private set
     var primaryCTAButtonActiveBackgroundColor by mutableStateOf(
-        primaryCTAButtonActiveBackgroundColor
+        primaryCTAButtonActiveBackgroundColor,
     )
         private set
     var primaryCTAButtonActiveTextColor by mutableStateOf(primaryCTAButtonActiveTextColor)
         private set
     var primaryCTAButtonDisabledBackgroundColor by mutableStateOf(
-        primaryCTAButtonDisabledBackgroundColor
+        primaryCTAButtonDisabledBackgroundColor,
     )
         private set
 
@@ -228,7 +228,7 @@ internal val LocalDojoColors = staticCompositionLocalOf<DojoColors> {
 
 private fun materialColors(
     dojoColors: DojoColors,
-    darkTheme: Boolean
+    darkTheme: Boolean,
 ) = Colors(
     primary = dojoColors.primary,
     onPrimary = dojoColors.onPrimary,
@@ -242,5 +242,5 @@ private fun materialColors(
     onSurface = dojoColors.onSurface,
     error = dojoColors.error,
     onError = dojoColors.onError,
-    isLight = !darkTheme
+    isLight = !darkTheme,
 )

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/navigation/PaymentFlowNavigationEvents.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/navigation/PaymentFlowNavigationEvents.kt
@@ -21,3 +21,6 @@ internal sealed class PaymentFlowNavigationEvents {
 
     object CardDetailsCheckoutAsFirstScreen : PaymentFlowNavigationEvents()
 }
+
+internal const val CUSTOMER_ID_PARAMS_KEY = "customerId"
+internal const val DOJO_PAYMENT_RESULT_PARAMS_KEY = "dojoPaymentResult"

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -9,7 +9,6 @@ import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
-import tech.dojo.pay.sdk.card.presentation.card.handler.DojoVirtualTerminalHandler
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentResult
 import tech.dojo.pay.uisdk.domain.GetSupportedCountriesUseCase
@@ -34,7 +33,6 @@ internal class CardDetailsCheckoutViewModel(
     private val supportedCountriesViewEntityMapper: SupportedCountriesViewEntityMapper,
     private val allowedPaymentMethodsViewEntityMapper: AllowedPaymentMethodsViewEntityMapper,
     private val cardCheckoutScreenValidator: CardCheckoutScreenValidator,
-    private var virtualTerminalHandler: DojoVirtualTerminalHandler
 ) : ViewModel() {
     private lateinit var paymentToken: String
     private var isVirtualTerminal = false
@@ -42,12 +40,8 @@ internal class CardDetailsCheckoutViewModel(
     private val mutableState = MutableLiveData<CardDetailsCheckoutState>()
     val state: LiveData<CardDetailsCheckoutState>
         get() = mutableState
-    fun updateCardPaymentHandler(
-        newDojoCardPaymentHandler: DojoCardPaymentHandler,
-        newVirtualTerminalHandler: DojoVirtualTerminalHandler
-    ) {
+    fun updateCardPaymentHandler(newDojoCardPaymentHandler: DojoCardPaymentHandler) {
         dojoCardPaymentHandler = newDojoCardPaymentHandler
-        virtualTerminalHandler = newVirtualTerminalHandler
     }
     init {
         currentState = CardDetailsCheckoutState(
@@ -68,10 +62,10 @@ internal class CardDetailsCheckoutViewModel(
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = true,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
         )
         pushStateToUi(currentState)
         viewModelScope.launch { observePaymentIntent() }
@@ -84,14 +78,14 @@ internal class CardDetailsCheckoutViewModel(
                 cardHolderInputField = InputFieldState(
                     value = "",
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_card_holder
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_card_holder,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         } else {
             currentState.copy(
                 cardHolderInputField = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(cardHolderValue = newValue)
+                isEnabled = isPayButtonEnabled(cardHolderValue = newValue),
             )
         }
 
@@ -104,14 +98,14 @@ internal class CardDetailsCheckoutViewModel(
                 postalCodeField = InputFieldState(
                     value = "",
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_billing_postcode,
-                    isError = true
+                    isError = true,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         } else {
             currentState.copy(
                 postalCodeField = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(postalCodeValue = newValue)
+                isEnabled = isPayButtonEnabled(postalCodeValue = newValue),
             )
         }
         pushStateToUi(currentState)
@@ -120,7 +114,7 @@ internal class CardDetailsCheckoutViewModel(
     fun onCardNumberValueChanged(newValue: String) {
         currentState = currentState.copy(
             cardNumberInputField = InputFieldState(value = newValue),
-            isEnabled = isPayButtonEnabled(cardNumberValue = newValue)
+            isEnabled = isPayButtonEnabled(cardNumberValue = newValue),
         )
         pushStateToUi(currentState)
     }
@@ -131,18 +125,18 @@ internal class CardDetailsCheckoutViewModel(
                 cardNumberInputField = InputFieldState(
                     value = "",
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_card_number
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_card_number,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         } else if (!cardCheckoutScreenValidator.isCardNumberValid(cardNumberValue)) {
             currentState = currentState.copy(
                 cardNumberInputField = InputFieldState(
                     value = cardNumberValue,
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_card_number
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_card_number,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         }
         pushStateToUi(currentState)
@@ -154,14 +148,14 @@ internal class CardDetailsCheckoutViewModel(
                 cvvInputFieldState = InputFieldState(
                     value = "",
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_cvv
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_cvv,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         } else {
             currentState.copy(
                 cvvInputFieldState = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(cvvValue = newValue)
+                isEnabled = isPayButtonEnabled(cvvValue = newValue),
             )
         }
 
@@ -177,9 +171,9 @@ internal class CardDetailsCheckoutViewModel(
                 cvvInputFieldState = InputFieldState(
                     value = cvvValue,
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_cvv
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_cvv,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         }
         pushStateToUi(currentState)
@@ -191,14 +185,14 @@ internal class CardDetailsCheckoutViewModel(
                 cardExpireDateInputField = InputFieldState(
                     value = "",
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_expiry
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_expiry,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         } else {
             currentState.copy(
                 cardExpireDateInputField = InputFieldState(newValue),
-                isEnabled = isPayButtonEnabled(cardExpireDate = newValue)
+                isEnabled = isPayButtonEnabled(cardExpireDate = newValue),
             )
         }
         pushStateToUi(currentState)
@@ -213,9 +207,9 @@ internal class CardDetailsCheckoutViewModel(
                 cardExpireDateInputField = InputFieldState(
                     value = expireDateValue,
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_expiry
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_expiry,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         }
         pushStateToUi(currentState)
@@ -227,14 +221,14 @@ internal class CardDetailsCheckoutViewModel(
                 emailInputField = InputFieldState(
                     value = newValue,
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_email
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_email,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         } else {
             currentState.copy(
                 emailInputField = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(emailValue = newValue)
+                isEnabled = isPayButtonEnabled(emailValue = newValue),
             )
         }
         pushStateToUi(currentState)
@@ -249,9 +243,9 @@ internal class CardDetailsCheckoutViewModel(
                 emailInputField = InputFieldState(
                     value = emailValue,
                     isError = true,
-                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_email
+                    errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_email,
                 ),
-                isEnabled = false
+                isEnabled = false,
             )
         }
         pushStateToUi(currentState)
@@ -262,8 +256,8 @@ internal class CardDetailsCheckoutViewModel(
             currentSelectedCountry = newValue,
             isPostalCodeFieldRequired = applyIsPostalCodeFieldRequiredLogic(
                 newValue,
-                currentState.isBillingCountryFieldRequired
-            )
+                currentState.isBillingCountryFieldRequired,
+            ),
         )
         pushStateToUi(currentState)
     }
@@ -274,7 +268,7 @@ internal class CardDetailsCheckoutViewModel(
         cvvValue: String = currentState.cvvInputFieldState.value,
         cardExpireDate: String = currentState.cardExpireDateInputField.value,
         emailValue: String = currentState.emailInputField.value,
-        postalCodeValue: String = currentState.postalCodeField.value
+        postalCodeValue: String = currentState.postalCodeField.value,
     ) =
         cardHolderValue.isNotBlank() &&
             cardCheckoutScreenValidator.isCardNumberValid(cardNumberValue) &&
@@ -282,11 +276,11 @@ internal class CardDetailsCheckoutViewModel(
             cardCheckoutScreenValidator.isCardExpireDateValid(cardExpireDate) &&
             cardCheckoutScreenValidator.isEmailFieldValidWithInputFieldVisibility(
                 emailValue,
-                currentState.isEmailInputFieldRequired
+                currentState.isEmailInputFieldRequired,
             ) &&
             cardCheckoutScreenValidator.isPostalCodeFieldWithInputFieldVisibility(
                 postalCodeValue,
-                currentState.isPostalCodeFieldRequired
+                currentState.isPostalCodeFieldRequired,
             )
 
     private suspend fun observePaymentIntent() {
@@ -308,27 +302,31 @@ internal class CardDetailsCheckoutViewModel(
                 amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
                 saveCardCheckBox = currentState.saveCardCheckBox.copy(isVisible = !paymentIntentResult.result.customerId.isNullOrBlank(), isChecked = !paymentIntentResult.result.customerId.isNullOrBlank()),
                 allowedPaymentMethodsIcons = allowedPaymentMethodsViewEntityMapper.apply(
-                    paymentIntentResult.result.supportedCardsSchemes
+                    paymentIntentResult.result.supportedCardsSchemes,
                 ),
                 isEmailInputFieldRequired = paymentIntentResult.result.collectionEmailRequired,
                 isBillingCountryFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
                 supportedCountriesList = countryList,
                 currentSelectedCountry = currentSelectedCountry,
-                isPostalCodeFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired
+                isPostalCodeFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
             )
             pushStateToUi(currentState)
         }
     }
 
     private fun getSupportedCountriesList(collectionBillingAddressRequired: Boolean): List<SupportedCountriesViewEntity> {
-        return if (collectionBillingAddressRequired) getSupportedCountriesUseCase
-            .getSupportedCountries()
-            .map { supportedCountriesViewEntityMapper.apply(it) } else emptyList()
+        return if (collectionBillingAddressRequired) {
+            getSupportedCountriesUseCase
+                .getSupportedCountries()
+                .map { supportedCountriesViewEntityMapper.apply(it) }
+        } else {
+            emptyList()
+        }
     }
 
     private fun applyIsPostalCodeFieldRequiredLogic(
         SupportedCountryItem: SupportedCountriesViewEntity,
-        collectionBillingAddressRequired: Boolean
+        collectionBillingAddressRequired: Boolean,
     ): Boolean {
         return SupportedCountryItem.isPostalCodeEnabled && collectionBillingAddressRequired
     }
@@ -350,11 +348,7 @@ internal class CardDetailsCheckoutViewModel(
         viewModelScope.launch { observePaymentIntent() }
         updatePaymentStateUseCase.updatePaymentSate(isActive = true)
         pushStateToUi(currentState.copy(isLoading = true))
-        if (isVirtualTerminal) {
-            virtualTerminalHandler.executeVirtualTerminalPayment(paymentToken, getPaymentPayLoad())
-        } else {
-            dojoCardPaymentHandler.executeCardPayment(paymentToken, getPaymentPayLoad())
-        }
+        dojoCardPaymentHandler.executeCardPayment(paymentToken, getPaymentPayLoad())
     }
 
     private fun pushStateToUi(state: CardDetailsCheckoutState) {
@@ -366,7 +360,7 @@ internal class CardDetailsCheckoutViewModel(
             userEmailAddress = if (currentState.isEmailInputFieldRequired) currentState.emailInputField.value else null,
             billingAddress = DojoAddressDetails(
                 countryCode = if (currentState.isBillingCountryFieldRequired) currentState.currentSelectedCountry.countryCode else null,
-                postcode = if (currentState.isPostalCodeFieldRequired) currentState.postalCodeField.value else null
+                postcode = if (currentState.isPostalCodeFieldRequired) currentState.postalCodeField.value else null,
             ),
             savePaymentMethod = currentState.saveCardCheckBox.isChecked,
             cardDetails = DojoCardDetails(
@@ -374,8 +368,8 @@ internal class CardDetailsCheckoutViewModel(
                 cardName = currentState.cardHolderInputField.value,
                 expiryMonth = getExpiryMonth(currentState.cardExpireDateInputField.value),
                 expiryYear = getExpiryYear(currentState.cardExpireDateInputField.value),
-                cv2 = currentState.cvvInputFieldState.value
-            )
+                cv2 = currentState.cvvInputFieldState.value,
+            ),
         )
 
     private fun getExpiryMonth(expireDateValueValue: String) =

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
-import tech.dojo.pay.sdk.card.presentation.card.handler.DojoVirtualTerminalHandler
 import tech.dojo.pay.uisdk.data.supportedcountries.SupportedCountriesDataSource
 import tech.dojo.pay.uisdk.data.supportedcountries.SupportedCountriesRepository
 import tech.dojo.pay.uisdk.domain.GetSupportedCountriesUseCase
@@ -19,8 +18,7 @@ import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.validator.CardChe
 class CardDetailsCheckoutViewModelFactory(
     private val dojoCardPaymentHandler: DojoCardPaymentHandler,
     private val isDarkModeEnabled: Boolean,
-    private val virtualTerminalHandler: DojoVirtualTerminalHandler,
-    private val context: Context
+    private val context: Context,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -31,10 +29,10 @@ class CardDetailsCheckoutViewModelFactory(
         val updatePaymentStateUseCase =
             UpdatePaymentStateUseCase(PaymentFlowViewModelFactory.paymentStatusRepository)
         val supportedCountriesRepository = SupportedCountriesRepository(
-            dataSource = SupportedCountriesDataSource(context)
+            dataSource = SupportedCountriesDataSource(context),
         )
         val getSupportedCountriesUseCase = GetSupportedCountriesUseCase(
-            supportedCountriesRepository = supportedCountriesRepository
+            supportedCountriesRepository = supportedCountriesRepository,
         )
         val supportedCountriesViewEntityMapper =
             SupportedCountriesViewEntityMapper()
@@ -51,7 +49,6 @@ class CardDetailsCheckoutViewModelFactory(
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         ) as T
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentDataSourceTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentDataSourceTest.kt
@@ -23,7 +23,26 @@ internal class PaymentIntentDataSourceTest {
         sut.fetchPaymentIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
         verify {
             DojoSdk.fetchPaymentIntent(
-                paymentId, onPaymentIntentSuccess, onPaymentIntentFailed
+                paymentId,
+                onPaymentIntentSuccess,
+                onPaymentIntentFailed,
+            )
+        }
+    }
+
+    @Test
+    fun `when calling fetchSetUpIntent , fetchSetUpIntent from DojoSdk should be called`() {
+        val paymentId = "paymentId"
+        val onPaymentIntentSuccess: (paymentIntentJson: String) -> Unit = {}
+        val onPaymentIntentFailed: () -> Unit = {}
+        val sut = PaymentIntentDataSource()
+
+        sut.fetchSetUpIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
+        verify {
+            DojoSdk.fetchSetUpIntent(
+                paymentId,
+                onPaymentIntentSuccess,
+                onPaymentIntentFailed,
             )
         }
     }
@@ -38,7 +57,9 @@ internal class PaymentIntentDataSourceTest {
         sut.refreshPaymentIntent(paymentId, onPaymentIntentSuccess, onPaymentIntentFailed)
         verify {
             DojoSdk.refreshPaymentIntent(
-                paymentId, onPaymentIntentSuccess, onPaymentIntentFailed
+                paymentId,
+                onPaymentIntentSuccess,
+                onPaymentIntentFailed,
             )
         }
     }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentRepositoryTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/data/paymentintent/PaymentIntentRepositoryTest.kt
@@ -33,7 +33,7 @@ internal class PaymentIntentRepositoryTest {
             dataSource.fetchPaymentIntent(
                 any(),
                 any(),
-                any()
+                any(),
             )
         }.answers { thirdArg<() -> Unit>().invoke() }
         val expectedValue = PaymentIntentResult.FetchFailure
@@ -48,23 +48,26 @@ internal class PaymentIntentRepositoryTest {
     }
 
     @Test
-    fun `when fetchPaymentIntent success  PaymentIntent stream should emits Success with domainEntity`() =
+    fun `when fetchPaymentIntent success PaymentIntent stream should emits Success with domainEntity`() =
         runTest {
             // arrange
             val paymentId = "paymentId"
             val paymentIntentJson = "paymentIntentJson"
             val paymentIntentDomainEntity = PaymentIntentDomainEntity(
-                id = "id", paymentToken = "clientSessionSecret",
+                id = "id",
+                paymentToken = "clientSessionSecret",
                 amount = AmountDomainEntity(
-                    10L, "0.10", "GBP"
+                    10L,
+                    "0.10",
+                    "GBP",
                 ),
-                supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD)
+                supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD),
             )
             every {
                 dataSource.fetchPaymentIntent(
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             }.answers { secondArg<(paymentIntentJson: String) -> Unit>().invoke(paymentIntentJson) }
             every { mapper.apply(any()) } returns paymentIntentDomainEntity
@@ -72,6 +75,63 @@ internal class PaymentIntentRepositoryTest {
             // act
             val sut = PaymentIntentRepository(dataSource, gson, mapper)
             sut.fetchPaymentIntent(paymentId)
+            val stream = sut.observePaymentIntent()
+
+            // assert
+            val job = launch { stream.collectLatest { assertEquals(expectedValue, it) } }
+            job.cancel()
+        }
+
+    @Test
+    fun `when fetchSetUpIntent fails PaymentIntent stream should emits FetchFailure`() = runTest {
+        // arrange
+        val paymentId = "paymentId"
+        every {
+            dataSource.fetchSetUpIntent(
+                any(),
+                any(),
+                any(),
+            )
+        }.answers { thirdArg<() -> Unit>().invoke() }
+        val expectedValue = PaymentIntentResult.FetchFailure
+        // act
+        val sut = PaymentIntentRepository(dataSource, gson, mapper)
+        sut.fetchSetUpIntent(paymentId)
+        val stream = sut.observePaymentIntent()
+
+        // assert
+        val job = launch { stream.collectLatest { assertEquals(expectedValue, it) } }
+        job.cancel()
+    }
+
+    @Test
+    fun `when fetchSetUpIntent success PaymentIntent stream should emits Success with domainEntity`() =
+        runTest {
+            // arrange
+            val paymentId = "paymentId"
+            val paymentIntentJson = "paymentIntentJson"
+            val paymentIntentDomainEntity = PaymentIntentDomainEntity(
+                id = "id",
+                paymentToken = "clientSessionSecret",
+                amount = AmountDomainEntity(
+                    10L,
+                    "0.10",
+                    "GBP",
+                ),
+                supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD),
+            )
+            every {
+                dataSource.fetchSetUpIntent(
+                    any(),
+                    any(),
+                    any(),
+                )
+            }.answers { secondArg<(paymentIntentJson: String) -> Unit>().invoke(paymentIntentJson) }
+            every { mapper.apply(any()) } returns paymentIntentDomainEntity
+            val expectedValue = PaymentIntentResult.Success(paymentIntentDomainEntity)
+            // act
+            val sut = PaymentIntentRepository(dataSource, gson, mapper)
+            sut.fetchSetUpIntent(paymentId)
             val stream = sut.observePaymentIntent()
 
             // assert
@@ -89,7 +149,7 @@ internal class PaymentIntentRepositoryTest {
                 dataSource.fetchPaymentIntent(
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             }.answers { secondArg<(paymentIntentJson: String) -> Unit>().invoke(paymentIntentJson) }
             every { mapper.apply(any()) } throws RuntimeException("A mock exception occurred!")
@@ -113,7 +173,7 @@ internal class PaymentIntentRepositoryTest {
                 dataSource.refreshPaymentIntent(
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             }.answers { thirdArg<() -> Unit>().invoke() }
             val expectedValue = PaymentIntentResult.RefreshFailure
@@ -134,17 +194,20 @@ internal class PaymentIntentRepositoryTest {
             val paymentId = "paymentId"
             val paymentIntentJson = "paymentIntentJson"
             val paymentIntentDomainEntity = PaymentIntentDomainEntity(
-                id = "id", paymentToken = "clientSessionSecret",
+                id = "id",
+                paymentToken = "clientSessionSecret",
                 amount = AmountDomainEntity(
-                    10L, "0.10", "GBP"
+                    10L,
+                    "0.10",
+                    "GBP",
                 ),
-                supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD)
+                supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD),
             )
             every {
                 dataSource.refreshPaymentIntent(
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             }.answers { secondArg<(paymentIntentJson: String) -> Unit>().invoke(paymentIntentJson) }
             every { mapper.apply(any()) } returns paymentIntentDomainEntity
@@ -169,7 +232,7 @@ internal class PaymentIntentRepositoryTest {
                 dataSource.refreshPaymentIntent(
                     any(),
                     any(),
-                    any()
+                    any(),
                 )
             }.answers { secondArg<(paymentIntentJson: String) -> Unit>().invoke(paymentIntentJson) }
             every { mapper.apply(any()) } throws RuntimeException("A mock exception occurred!")

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCaseTest.kt
@@ -5,6 +5,7 @@ import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import tech.dojo.pay.uisdk.data.paymentintent.PaymentIntentRepository
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 
 class FetchPaymentIntentUseCaseTest {
 
@@ -18,16 +19,44 @@ class FetchPaymentIntentUseCaseTest {
     }
 
     @Test
-    fun `fetchPaymentIntent should call repository fetchPaymentIntent`() {
+    fun `given calling fetchPaymentIntentWithPaymentType with payment type as PAYMENT_CARD should call repository fetchPaymentIntent`() {
         // given
         val paymentId = "paymentId"
 
         // when
-        useCase.fetchPaymentIntent(paymentId)
+        useCase.fetchPaymentIntentWithPaymentType(DojoPaymentType.PAYMENT_CARD, paymentId)
 
         // then
         verify {
             repository.fetchPaymentIntent(paymentId)
+        }
+    }
+
+    @Test
+    fun `given calling fetchPaymentIntentWithPaymentType with payment type as VIRTUAL_TERMINAL should call repository fetchPaymentIntent`() {
+        // given
+        val paymentId = "paymentId"
+
+        // when
+        useCase.fetchPaymentIntentWithPaymentType(DojoPaymentType.VIRTUAL_TERMINAL, paymentId)
+
+        // then
+        verify {
+            repository.fetchPaymentIntent(paymentId)
+        }
+    }
+
+    @Test
+    fun `given calling fetchPaymentIntentWithPaymentType with payment type as CARD_ON_FILE should call repository fetchSetUpIntent`() {
+        // given
+        val paymentId = "paymentId"
+
+        // when
+        useCase.fetchPaymentIntentWithPaymentType(DojoPaymentType.CARD_ON_FILE, paymentId)
+
+        // then
+        verify {
+            repository.fetchSetUpIntent(paymentId)
         }
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCaseTest.kt
@@ -5,6 +5,7 @@ import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import tech.dojo.pay.uisdk.data.paymentmethods.PaymentMethodsRepository
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 
 class FetchPaymentMethodsUseCaseTest {
 
@@ -18,13 +19,53 @@ class FetchPaymentMethodsUseCaseTest {
     }
 
     @Test
-    fun `fetchPaymentMethods should call repository fetchPaymentMethods`() {
+    fun `when fetchPaymentMethodsWithPaymentType with payment intent as CARD_ON_FILE should not call repository fetchPaymentMethods`() {
         // given
         val customerId = "customerId"
         val customerSecret = "customerSecret"
 
         // when
-        useCase.fetchPaymentMethods(customerId, customerSecret)
+        useCase.fetchPaymentMethodsWithPaymentType(
+            DojoPaymentType.CARD_ON_FILE,
+            customerId,
+            customerSecret,
+        )
+
+        // then
+        verify(exactly = 0) { repository.fetchPaymentMethod(customerId, customerSecret) }
+    }
+
+    @Test
+    fun `when fetchPaymentMethodsWithPaymentType with payment intent as PAYMENT_CARD should call repository fetchPaymentMethods`() {
+        // given
+        val customerId = "customerId"
+        val customerSecret = "customerSecret"
+
+        // when
+        useCase.fetchPaymentMethodsWithPaymentType(
+            DojoPaymentType.PAYMENT_CARD,
+            customerId,
+            customerSecret,
+        )
+
+        // then
+        verify {
+            repository.fetchPaymentMethod(customerId, customerSecret)
+        }
+    }
+
+    @Test
+    fun `when fetchPaymentMethodsWithPaymentType with payment intent as VIRTUAL_TERMINAL should call repository fetchPaymentMethods`() {
+        // given
+        val customerId = "customerId"
+        val customerSecret = "customerSecret"
+
+        // when
+        useCase.fetchPaymentMethodsWithPaymentType(
+            DojoPaymentType.VIRTUAL_TERMINAL,
+            customerId,
+            customerSecret,
+        )
 
         // then
         verify {

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -28,6 +28,7 @@ import tech.dojo.pay.uisdk.entities.LightColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.darkColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.lightColorPalette
 import tech.dojo.pay.uisdk.presentation.navigation.PaymentFlowNavigationEvents
+import tech.dojo.pay.uisdk.presentation.navigation.PaymentFlowScreens
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
@@ -41,7 +42,7 @@ internal class PaymentFlowViewModelTest {
 
     private val paymentId: String = "paymentId"
     private val customerSecret: String = "customerSecret"
-    private val paymentType: DojoPaymentType = DojoPaymentType.PAYMENT_CARD
+    private var paymentType: DojoPaymentType = DojoPaymentType.PAYMENT_CARD
     private val fetchPaymentIntentUseCase: FetchPaymentIntentUseCase = mock()
     private val observePaymentIntent: ObservePaymentIntent = mock()
     private val fetchPaymentMethodsUseCase: FetchPaymentMethodsUseCase = mock()
@@ -568,5 +569,68 @@ internal class PaymentFlowViewModelTest {
         val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = false)
         // assert
         Assert.assertEquals(expected.primarySurfaceBackgroundColor, actual.primarySurfaceBackgroundColor)
+    }
+
+    @Test
+    fun`given calling getFlowStartDestination with PAYMENT_CARD type the start destination should be PaymentMethodCheckout`() = runTest {
+        // arrange
+        val expected = PaymentFlowScreens.PaymentMethodCheckout
+        paymentType = DojoPaymentType.PAYMENT_CARD
+        val viewModel = PaymentFlowViewModel(
+            "Sandbox_paymentId",
+            customerSecret,
+            paymentType,
+            fetchPaymentIntentUseCase,
+            observePaymentIntent,
+            fetchPaymentMethodsUseCase,
+            updatePaymentStateUseCase,
+        )
+
+        // act
+        val actual = viewModel.getFlowStartDestination()
+        // assert
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun`given calling getFlowStartDestination with CARD_ON_FILE type the start destination should be CardDetailsCheckout`() = runTest {
+        // arrange
+        val expected = PaymentFlowScreens.CardDetailsCheckout
+        paymentType = DojoPaymentType.CARD_ON_FILE
+        val viewModel = PaymentFlowViewModel(
+            "Sandbox_paymentId",
+            customerSecret,
+            paymentType,
+            fetchPaymentIntentUseCase,
+            observePaymentIntent,
+            fetchPaymentMethodsUseCase,
+            updatePaymentStateUseCase,
+        )
+
+        // act
+        val actual = viewModel.getFlowStartDestination()
+        // assert
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun`given calling getFlowStartDestination with VIRTUAL_TERMINAL type the start destination should be VirtualTerminalCheckOutScreen`() = runTest {
+        // arrange
+        val expected = PaymentFlowScreens.VirtualTerminalCheckOutScreen
+        paymentType = DojoPaymentType.VIRTUAL_TERMINAL
+        val viewModel = PaymentFlowViewModel(
+            "Sandbox_paymentId",
+            customerSecret,
+            paymentType,
+            fetchPaymentIntentUseCase,
+            observePaymentIntent,
+            fetchPaymentMethodsUseCase,
+            updatePaymentStateUseCase,
+        )
+
+        // act
+        val actual = viewModel.getFlowStartDestination()
+        // assert
+        Assert.assertEquals(expected, actual)
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -22,6 +22,10 @@ import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
 import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
+import tech.dojo.pay.uisdk.entities.DarkColorPalette
+import tech.dojo.pay.uisdk.entities.LightColorPalette
+import tech.dojo.pay.uisdk.presentation.components.theme.darkColorPalette
+import tech.dojo.pay.uisdk.presentation.components.theme.lightColorPalette
 import tech.dojo.pay.uisdk.presentation.navigation.PaymentFlowNavigationEvents
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -59,7 +63,7 @@ internal class PaymentFlowViewModelTest {
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
-                updatePaymentStateUseCase
+                updatePaymentStateUseCase,
             )
             val actual = viewModel.navigationEvent.value
             // assert
@@ -81,13 +85,13 @@ internal class PaymentFlowViewModelTest {
                         AmountDomainEntity(
                             10L,
                             "100",
-                            "GBP"
+                            "GBP",
                         ),
                         supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                         collectionBillingAddressRequired = true,
-                        customerId = "customerId"
-                    )
-                )
+                        customerId = "customerId",
+                    ),
+                ),
             )
             // act
             PaymentFlowViewModel(
@@ -97,7 +101,7 @@ internal class PaymentFlowViewModelTest {
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
-                updatePaymentStateUseCase
+                updatePaymentStateUseCase,
             )
             // assert
             verify(fetchPaymentMethodsUseCase).fetchPaymentMethods("customerId", customerSecret)
@@ -118,13 +122,13 @@ internal class PaymentFlowViewModelTest {
                         AmountDomainEntity(
                             10L,
                             "100",
-                            "GBP"
+                            "GBP",
                         ),
                         supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                         collectionBillingAddressRequired = true,
-                        customerId = "customerId"
-                    )
-                )
+                        customerId = "customerId",
+                    ),
+                ),
             )
             // act
             val viewModel = PaymentFlowViewModel(
@@ -134,7 +138,7 @@ internal class PaymentFlowViewModelTest {
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
-                updatePaymentStateUseCase
+                updatePaymentStateUseCase,
             )
             viewModel.updatePaymentState(isActivity = false)
             // assert
@@ -156,13 +160,13 @@ internal class PaymentFlowViewModelTest {
                         AmountDomainEntity(
                             10L,
                             "100",
-                            "GBP"
+                            "GBP",
                         ),
                         supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                         collectionBillingAddressRequired = true,
-                        customerId = "customerId"
-                    )
-                )
+                        customerId = "customerId",
+                    ),
+                ),
             )
             // act
             val viewModel = PaymentFlowViewModel(
@@ -172,7 +176,7 @@ internal class PaymentFlowViewModelTest {
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
-                updatePaymentStateUseCase
+                updatePaymentStateUseCase,
             )
             viewModel.updateGpayPaymentState(isActivity = false)
             // assert
@@ -193,13 +197,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.OnBack
         // act
@@ -210,7 +214,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.onBackClicked()
         val actual = viewModel.navigationEvent.value
@@ -232,13 +236,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.PaymentMethodsCheckOutWithSelectedPaymentMethod()
         // act
@@ -249,7 +253,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.onBackClickedWithSavedPaymentMethod()
         val actual = viewModel.navigationEvent.value
@@ -271,13 +275,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.OnCloseFlow
         // act
@@ -288,7 +292,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.onCloseFlowClicked()
         val actual = viewModel.navigationEvent.value
@@ -310,13 +314,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
         // act
@@ -327,7 +331,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.navigateToPaymentResult(DojoPaymentResult.SUCCESSFUL)
         val actual = viewModel.navigationEvent.value
@@ -349,13 +353,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SDK_INTERNAL_ERROR, false)
         // act
@@ -366,7 +370,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.navigateToPaymentResult(DojoPaymentResult.SDK_INTERNAL_ERROR)
         val actual = viewModel.navigationEvent.value
@@ -388,13 +392,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.FAILED, false)
         // act
@@ -405,7 +409,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.navigateToPaymentResult(DojoPaymentResult.FAILED)
         val actual = viewModel.navigationEvent.value
@@ -427,13 +431,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.CardDetailsCheckout
         // act
@@ -444,7 +448,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.navigateToCardDetailsCheckoutScreen()
         val actual = viewModel.navigationEvent.value
@@ -466,13 +470,13 @@ internal class PaymentFlowViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
-                    customerId = "customerId"
-                )
-            )
+                    customerId = "customerId",
+                ),
+            ),
         )
         val expected = PaymentFlowNavigationEvents.ManagePaymentMethods("customerId")
         // act
@@ -483,7 +487,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         viewModel.navigateToManagePaymentMethods()
         val actual = viewModel.navigationEvent.value
@@ -501,7 +505,7 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         // act
         val actual = viewModel.isPaymentInSandBoxEnvironment()
@@ -519,11 +523,49 @@ internal class PaymentFlowViewModelTest {
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase
+            updatePaymentStateUseCase,
         )
         // act
         val actual = viewModel.isPaymentInSandBoxEnvironment()
         // assert
         Assert.assertTrue(actual)
+    }
+
+    @Test
+    fun `call getCustomColorPalette with isDarkModeEnabled as true  should return darkColorPalette `() = runTest {
+        // arrange
+        val expected = darkColorPalette(DarkColorPalette())
+        val viewModel = PaymentFlowViewModel(
+            "Sandbox_paymentId",
+            customerSecret,
+            isVirtualTerminalPayment,
+            fetchPaymentIntentUseCase,
+            observePaymentIntent,
+            fetchPaymentMethodsUseCase,
+            updatePaymentStateUseCase,
+        )
+        // act
+        val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = true)
+        // assert
+        Assert.assertEquals(expected.primarySurfaceBackgroundColor, actual.primarySurfaceBackgroundColor)
+    }
+
+    @Test
+    fun `call getCustomColorPalette with isDarkModeEnabled as false should return LightColorPalette `() = runTest {
+        // arrange
+        val expected = lightColorPalette(LightColorPalette())
+        val viewModel = PaymentFlowViewModel(
+            "Sandbox_paymentId",
+            customerSecret,
+            isVirtualTerminalPayment,
+            fetchPaymentIntentUseCase,
+            observePaymentIntent,
+            fetchPaymentMethodsUseCase,
+            updatePaymentStateUseCase,
+        )
+        // act
+        val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = false)
+        // assert
+        Assert.assertEquals(expected.primarySurfaceBackgroundColor, actual.primarySurfaceBackgroundColor)
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -106,7 +106,7 @@ internal class PaymentFlowViewModelTest {
                 updatePaymentStateUseCase,
             )
             // assert
-            verify(fetchPaymentMethodsUseCase).fetchPaymentMethods("customerId", customerSecret)
+            verify(fetchPaymentMethodsUseCase).fetchPaymentMethodsWithPaymentType(DojoPaymentType.PAYMENT_CARD, "customerId", customerSecret)
         }
 
     @Test

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -23,6 +23,7 @@ import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.entities.DarkColorPalette
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
 import tech.dojo.pay.uisdk.entities.LightColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.darkColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.lightColorPalette
@@ -40,7 +41,7 @@ internal class PaymentFlowViewModelTest {
 
     private val paymentId: String = "paymentId"
     private val customerSecret: String = "customerSecret"
-    private val isVirtualTerminalPayment: Boolean = false
+    private val paymentType: DojoPaymentType = DojoPaymentType.PAYMENT_CARD
     private val fetchPaymentIntentUseCase: FetchPaymentIntentUseCase = mock()
     private val observePaymentIntent: ObservePaymentIntent = mock()
     private val fetchPaymentMethodsUseCase: FetchPaymentMethodsUseCase = mock()
@@ -59,7 +60,7 @@ internal class PaymentFlowViewModelTest {
             val viewModel = PaymentFlowViewModel(
                 paymentId,
                 customerSecret,
-                isVirtualTerminalPayment,
+                paymentType,
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
@@ -97,7 +98,7 @@ internal class PaymentFlowViewModelTest {
             PaymentFlowViewModel(
                 paymentId,
                 customerSecret,
-                isVirtualTerminalPayment,
+                paymentType,
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
@@ -134,7 +135,7 @@ internal class PaymentFlowViewModelTest {
             val viewModel = PaymentFlowViewModel(
                 paymentId,
                 customerSecret,
-                isVirtualTerminalPayment,
+                paymentType,
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
@@ -172,7 +173,7 @@ internal class PaymentFlowViewModelTest {
             val viewModel = PaymentFlowViewModel(
                 paymentId,
                 customerSecret,
-                isVirtualTerminalPayment,
+                paymentType,
                 fetchPaymentIntentUseCase,
                 observePaymentIntent,
                 fetchPaymentMethodsUseCase,
@@ -210,7 +211,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -249,7 +250,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -288,7 +289,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -327,7 +328,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -366,7 +367,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -405,7 +406,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -444,7 +445,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -483,7 +484,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -501,7 +502,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             paymentId,
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -519,7 +520,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             "Sandbox_paymentId",
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -538,7 +539,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             "Sandbox_paymentId",
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
@@ -557,7 +558,7 @@ internal class PaymentFlowViewModelTest {
         val viewModel = PaymentFlowViewModel(
             "Sandbox_paymentId",
             customerSecret,
-            isVirtualTerminalPayment,
+            paymentType,
             fetchPaymentIntentUseCase,
             observePaymentIntent,
             fetchPaymentMethodsUseCase,

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
-import tech.dojo.pay.sdk.card.presentation.card.handler.DojoVirtualTerminalHandlerImp
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.core.MainCoroutineScopeRule
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentResult
@@ -52,7 +51,6 @@ class CardDetailsCheckoutViewModelTest {
     private val allowedPaymentMethodsViewEntityMapper: AllowedPaymentMethodsViewEntityMapper =
         mock()
     private val cardCheckoutScreenValidator: CardCheckoutScreenValidator = mock()
-    private val virtualTerminalHandler: DojoVirtualTerminalHandlerImp = mock()
 
     @Test
     fun `test initial state`() = runTest {
@@ -76,13 +74,13 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = true,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -94,7 +92,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -116,11 +113,11 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX)
-                )
-            )
+                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
@@ -141,11 +138,11 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -157,7 +154,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -184,18 +180,18 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true
-                )
-            )
+                    collectionBillingAddressRequired = true,
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -217,11 +213,11 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
 
         )
         // act
@@ -234,7 +230,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -261,19 +256,19 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     customerId = "customerId",
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true
-                )
-            )
+                    collectionBillingAddressRequired = true,
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -295,11 +290,11 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
 
         )
         // act
@@ -312,7 +307,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -339,18 +333,18 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true
-                )
-            )
+                    collectionBillingAddressRequired = true,
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -371,12 +365,12 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
             isLoading = true,
-            isEnabled = false
+            isEnabled = false,
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -388,69 +382,12 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         viewModel.onPayWithCardClicked()
         // assert
         verify(updatePaymentStateUseCase).updatePaymentSate(any())
         verify(dojoCardPaymentHandler).executeCardPayment(any(), any())
         Assert.assertEquals(expected, viewModel.state.value)
-    }
-
-    @Test
-    fun `when user click on pay for virtual terminal payment should call executeVirtualTerminalPayment from virtualTerminalHandler`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP"
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    isVirtualTerminalPayment = true
-                )
-            )
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
-        )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            virtualTerminalHandler
-        )
-        viewModel.onPayWithCardClicked()
-        // assert
-        verify(updatePaymentStateUseCase).updatePaymentSate(any())
-        verify(virtualTerminalHandler).executeVirtualTerminalPayment(any(), any())
     }
 
     @Test
@@ -474,18 +411,18 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true
-                )
-            )
+                    collectionBillingAddressRequired = true,
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -506,12 +443,12 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -523,7 +460,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         viewModel.onPayWithCardClicked()
         paymentStateFakeFlow.tryEmit(false)
@@ -542,14 +478,14 @@ class CardDetailsCheckoutViewModelTest {
         whenever(
             cardCheckoutScreenValidator.isEmailFieldValidWithInputFieldVisibility(
                 any(),
-                any()
-            )
+                any(),
+            ),
         ).thenReturn(true)
         whenever(
             cardCheckoutScreenValidator.isPostalCodeFieldWithInputFieldVisibility(
                 any(),
-                any()
-            )
+                any(),
+            ),
         ).thenReturn(true)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
@@ -567,18 +503,18 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true
-                )
-            )
+                    collectionBillingAddressRequired = true,
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -599,12 +535,12 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = true
+            isEnabled = true,
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -616,7 +552,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
 
         viewModel.onCardHolderValueChanged("new")
@@ -645,18 +580,18 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true
-                )
-            )
+                    collectionBillingAddressRequired = true,
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -677,12 +612,12 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -694,7 +629,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         viewModel.onCardNumberValueChanged("new")
         viewModel.onCvvValueChanged("new")
@@ -724,19 +658,19 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
                     collectionEmailRequired = true,
-                )
-            )
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -754,7 +688,7 @@ class CardDetailsCheckoutViewModelTest {
             saveCardCheckBox = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card
+                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
@@ -762,7 +696,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
             isLoading = false,
-            isEnabled = false
+            isEnabled = false,
 
         )
         // act
@@ -775,7 +709,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         viewModel.onEmailValueChanged("new")
         // assert
@@ -807,19 +740,19 @@ class CardDetailsCheckoutViewModelTest {
                     AmountDomainEntity(
                         10L,
                         "100",
-                        "GBP"
+                        "GBP",
                     ),
                     supportedCardsSchemes = listOf(CardsSchemes.AMEX),
                     collectionBillingAddressRequired = true,
                     collectionEmailRequired = true,
-                )
-            )
+                ),
+            ),
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
             listOf(
-                SupportedCountriesDomainEntity("", "", false)
-            )
+                SupportedCountriesDomainEntity("", "", false),
+            ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
@@ -834,7 +767,6 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
-            virtualTerminalHandler
         )
         viewModel.validateCvv("new", false)
         viewModel.validateCardNumber("new")


### PR DESCRIPTION
## what 
- make the UI skd support card on file payment on the data and domain layer 
- make a clean up on the payment flow view model and the activity 
- update unit tests and add missing once 