### PR TITLE
Feature/rmcx 2733 update UI sdk to support setup intent configuration

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -36,7 +36,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
                 DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),
             )
         }
-        uiSdkSampleBinding.startPaymentFlowWithTheme.setOnClickListener {
+        uiSdkSampleBinding.startPaymentFlowWithVT.setOnClickListener {
             DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = true)
             dojoPayUI.startPaymentFlow(
                 DojoPaymentFlowParams(
@@ -48,6 +48,21 @@ class UiSdkSampleActivity : AppCompatActivity() {
                         gatewayMerchantId = "119784244252745",
                     ),
                     paymentType = DojoPaymentType.VIRTUAL_TERMINAL,
+                ),
+            )
+        }
+        uiSdkSampleBinding.startPaymentFlowCOF.setOnClickListener {
+            DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = true)
+            dojoPayUI.startPaymentFlow(
+                DojoPaymentFlowParams(
+                    uiSdkSampleBinding.token.text.toString(),
+                    secret,
+                    GPayConfig = DojoGPayConfig(
+                        merchantName = "Dojo Cafe (Paymentsense)",
+                        merchantId = "BCR2DN6T57R5ZI34",
+                        gatewayMerchantId = "119784244252745",
+                    ),
+                    paymentType = DojoPaymentType.SETUP_INTENT,
                 ),
             )
         }

--- a/sample/src/main/res/layout/activity_ui_sdk_sample.xml
+++ b/sample/src/main/res/layout/activity_ui_sdk_sample.xml
@@ -29,7 +29,6 @@
         app:layout_constraintTop_toBottomOf="@+id/startPaymentFlowWithVT"
         app:layout_constraintVertical_bias="0.192" />
 
-
     <FrameLayout
         android:id="@+id/viewProgress"
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/activity_ui_sdk_sample.xml
+++ b/sample/src/main/res/layout/activity_ui_sdk_sample.xml
@@ -2,10 +2,8 @@
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
 
     <Button
         android:id="@+id/startPaymentFlowWithVT"

--- a/sample/src/main/res/layout/activity_ui_sdk_sample.xml
+++ b/sample/src/main/res/layout/activity_ui_sdk_sample.xml
@@ -47,6 +47,7 @@
             android:layout_gravity="center" />
 
     </FrameLayout>
+
     <androidx.appcompat.widget.AppCompatCheckBox
         android:id="@+id/checkboxSandbox"
         android:layout_width="wrap_content"

--- a/sample/src/main/res/layout/activity_ui_sdk_sample.xml
+++ b/sample/src/main/res/layout/activity_ui_sdk_sample.xml
@@ -8,7 +8,7 @@
 
 
     <Button
-        android:id="@+id/startPaymentFlowWithTheme"
+        android:id="@+id/startPaymentFlowWithVT"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
@@ -18,6 +18,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/startPaymentFlow"
         app:layout_constraintVertical_bias="0.192" />
+
+    <Button
+        android:id="@+id/startPaymentFlowCOF"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="start Set UP Intent  Payment With force lightTheme"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/startPaymentFlowWithVT"
+        app:layout_constraintVertical_bias="0.192" />
+
 
     <FrameLayout
         android:id="@+id/viewProgress"

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/data/entities/PaymentDetails.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/data/entities/PaymentDetails.kt
@@ -6,6 +6,7 @@ import tech.dojo.pay.sdk.card.entities.DojoShippingDetails
 internal data class PaymentDetails(
     val cV2: String?,
     val savePaymentMethod: Boolean? = null,
+    val mitConsentGiven: Boolean? = null,
     val cardName: String? = null,
     val cardNumber: String? = null,
     val expiryDate: String? = null,

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/data/entities/PaymentDetails.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/data/entities/PaymentDetails.kt
@@ -5,7 +5,7 @@ import tech.dojo.pay.sdk.card.entities.DojoShippingDetails
 
 internal data class PaymentDetails(
     val cV2: String?,
-    val savePaymentMethod: Boolean? = null,
+    val savePaymentMethod: Boolean? = null, // this is for the SetUp Intent payments it needs to be true
     val mitConsentGiven: Boolean? = null,
     val cardName: String? = null,
     val cardNumber: String? = null,

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/data/mappers/CardPaymentRequestMapper.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/data/mappers/CardPaymentRequestMapper.kt
@@ -20,10 +20,11 @@ internal class CardPaymentRequestMapper {
             expiryDate = formatExpiryDate(cardDetails.expiryMonth, cardDetails.expiryYear),
             userEmailAddress = userEmailAddress,
             savePaymentMethod = savePaymentMethod,
+            mitConsentGiven = cardDetails.mitConsentGiven,
             userPhoneNumber = userPhoneNumber,
             billingAddress = billingAddress,
             shippingDetails = shippingDetails,
-            metaData = metaData
+            metaData = metaData,
         )
 
     private fun DojoCardPaymentPayLoad.SavedCardPaymentPayLoad.toPaymentDetails(): PaymentDetails =
@@ -33,7 +34,7 @@ internal class CardPaymentRequestMapper {
             userEmailAddress = userEmailAddress,
             userPhoneNumber = userPhoneNumber,
             shippingDetails = shippingDetails,
-            metaData = metaData
+            metaData = metaData,
         )
 
     /**

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/entities/DojoCardDetails.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/entities/DojoCardDetails.kt
@@ -7,5 +7,6 @@ data class DojoCardDetails(
     val cardName: String? = null,
     val expiryMonth: String? = null,
     val expiryYear: String? = null,
-    val cv2: String? = null
+    val cv2: String? = null,
+    val mitConsentGiven: Boolean? = null,
 ) : Serializable

--- a/sdk/src/test/java/tech/dojo/pay/sdk/card/data/mappers/CardPaymentRequestMapperTest.kt
+++ b/sdk/src/test/java/tech/dojo/pay/sdk/card/data/mappers/CardPaymentRequestMapperTest.kt
@@ -27,7 +27,7 @@ internal class CardPaymentRequestMapperTest {
             userEmailAddress = "user@gmail.com",
             userPhoneNumber = "123456789",
             shippingDetails = SHIPPING_DETAILS,
-            metaData = mapOf("1" to "one")
+            metaData = mapOf("1" to "one"),
         )
         val actual = CardPaymentRequestMapper().mapToPaymentDetails(SAVED_CARD_PAYLOAD)
         Assert.assertEquals(paymentDetailsForSavedCard, actual)
@@ -39,7 +39,8 @@ internal class CardPaymentRequestMapperTest {
             cardName = "Card holder",
             expiryMonth = "12",
             expiryYear = "24",
-            cv2 = "020"
+            cv2 = "020",
+            mitConsentGiven = true,
         )
 
         val ADDRESS_DETAILS = DojoAddressDetails(
@@ -47,12 +48,12 @@ internal class CardPaymentRequestMapperTest {
             city = "City",
             state = "State",
             postcode = "Postcode",
-            countryCode = "Country"
+            countryCode = "Country",
         )
 
         val SHIPPING_DETAILS = DojoShippingDetails(
             name = "name",
-            address = ADDRESS_DETAILS
+            address = ADDRESS_DETAILS,
         )
 
         val FULL_CARD_PAYLOAD = DojoCardPaymentPayLoad.FullCardPaymentPayload(
@@ -61,7 +62,7 @@ internal class CardPaymentRequestMapperTest {
             userPhoneNumber = "123456789",
             billingAddress = ADDRESS_DETAILS,
             shippingDetails = SHIPPING_DETAILS,
-            metaData = mapOf("1" to "one")
+            metaData = mapOf("1" to "one"),
         )
         val SAVED_CARD_PAYLOAD = DojoCardPaymentPayLoad.SavedCardPaymentPayLoad(
             cv2 = "cvv",
@@ -69,7 +70,7 @@ internal class CardPaymentRequestMapperTest {
             userEmailAddress = "user@gmail.com",
             userPhoneNumber = "123456789",
             shippingDetails = SHIPPING_DETAILS,
-            metaData = mapOf("1" to "one")
+            metaData = mapOf("1" to "one"),
         )
         val paymentDetails = PaymentDetails(
             cardNumber = CARD_DETAILS.cardNumber,
@@ -80,7 +81,8 @@ internal class CardPaymentRequestMapperTest {
             userPhoneNumber = FULL_CARD_PAYLOAD.userPhoneNumber,
             billingAddress = ADDRESS_DETAILS,
             shippingDetails = SHIPPING_DETAILS,
-            metaData = FULL_CARD_PAYLOAD.metaData
+            metaData = FULL_CARD_PAYLOAD.metaData,
+            mitConsentGiven = true,
         )
     }
 }

--- a/uisdk/build.gradle.kts
+++ b/uisdk/build.gradle.kts
@@ -72,8 +72,6 @@ dependencies {
     implementation(AndroidX.Compose.runtime)
     implementation(AndroidX.Compose.material)
     implementation(AndroidX.Compose.iconsExtended)
-    implementation(AndroidX.Compose.animation)
-    implementation(AndroidX.Compose.tooling)
     implementation(AndroidX.Compose.livedata)
     implementation(AndroidX.Compose.tooling)
     implementation(AndroidX.Logging.TIMBER)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/core/StringProvider.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/core/StringProvider.kt
@@ -1,0 +1,13 @@
+package tech.dojo.pay.uisdk.core
+
+import android.content.Context
+import androidx.annotation.StringRes
+
+class StringProvider(private val context: Context) {
+
+    fun getString(
+        @StringRes stringId: Int,
+    ): String {
+        return context.getString(stringId)
+    }
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
@@ -26,7 +26,6 @@ internal data class PaymentIntentPayload(
     val config: Config? = null,
     val itemLines: List<ItemLines>? = null,
     val merchantInitiatedType: String? = null,
-    val setupSource: String? = null,
     val metadata: Metadata? = null,
 )
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
@@ -25,17 +25,19 @@ internal data class PaymentIntentPayload(
     val paymentSource: String? = null,
     val config: Config? = null,
     val itemLines: List<ItemLines>? = null,
-    val metadata: Metadata? = null
+    val merchantInitiatedType: String? = null,
+    val setupSource: String? = null,
+    val metadata: Metadata? = null,
 )
 
 internal data class ItemLines(
     val caption: String,
-    val amountTotal: Amount
+    val amountTotal: Amount,
 )
 
 internal data class Amount(
     val value: Long,
-    val currencyCode: String
+    val currencyCode: String,
 )
 
 internal data class Config(
@@ -43,33 +45,33 @@ internal data class Config(
     val branding: Branding,
     val customerEmail: CustomerEmail,
     val billingAddress: BillingAddress,
-    val shippingDetails: ShippingAddress
+    val shippingDetails: ShippingAddress,
 )
 
 internal data class CustomerEmail(
-    val collectionRequired: Boolean
+    val collectionRequired: Boolean,
 )
 
 data class BillingAddress(
-    val collectionRequired: Boolean
+    val collectionRequired: Boolean,
 )
 
 data class ShippingAddress(
-    val collectionRequired: Boolean
+    val collectionRequired: Boolean,
 )
 
 internal data class Branding(
     val logoURL: String,
-    val faviconURL: String
+    val faviconURL: String,
 )
 
 internal data class MerchantConfig(
-    val supportedPaymentMethods: SupportedPaymentMethods? = null
+    val supportedPaymentMethods: SupportedPaymentMethods? = null,
 )
 
 internal data class SupportedPaymentMethods(
     val cardSchemes: List<CardsSchemes>? = null,
-    val wallets: List<WalletSchemes>? = null
+    val wallets: List<WalletSchemes>? = null,
 )
 
 data class Metadata(val locationID: String)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
@@ -12,6 +12,7 @@ internal data class PaymentIntentPayload(
     val status: String? = null,
     val paymentMethods: List<String>? = null,
     val amount: Amount? = null,
+    val intendedAmount: Amount? = null,
     val tipsAmount: Amount? = null,
     val requestedAmount: Amount? = null,
     val customer: Customer? = null,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCase.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCase.kt
@@ -10,7 +10,7 @@ internal class FetchPaymentIntentUseCase(
         when (paymentType) {
             DojoPaymentType.PAYMENT_CARD -> fetchPaymentIntent(paymentId)
             DojoPaymentType.VIRTUAL_TERMINAL -> fetchPaymentIntent(paymentId)
-            DojoPaymentType.CARD_ON_FILE -> fetchSetUpIntent(paymentId)
+            DojoPaymentType.SETUP_INTENT -> fetchSetUpIntent(paymentId)
         }
     }
     private fun fetchPaymentIntent(paymentId: String) {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCase.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCase.kt
@@ -12,7 +12,7 @@ internal class FetchPaymentMethodsUseCase(
         customerId: String,
         customerSecret: String,
     ) {
-        if (paymentType != DojoPaymentType.CARD_ON_FILE) {
+        if (paymentType != DojoPaymentType.SETUP_INTENT) {
             fetchPaymentMethods(customerId, customerSecret)
         }
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCase.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCase.kt
@@ -1,0 +1,15 @@
+package tech.dojo.pay.uisdk.domain
+
+import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
+
+internal class IsSDKInitializedCorrectlyUseCase {
+    fun isSDKInitiatedCorrectly(
+        paymentIntent: PaymentIntentDomainEntity,
+        paymentType: DojoPaymentType,
+    ) = when (paymentType) {
+        DojoPaymentType.VIRTUAL_TERMINAL -> paymentIntent.isVirtualTerminalPayment
+        DojoPaymentType.SETUP_INTENT -> paymentIntent.isSetUpIntentPayment
+        DojoPaymentType.PAYMENT_CARD -> !paymentIntent.isVirtualTerminalPayment && !paymentIntent.isSetUpIntentPayment
+    }
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
@@ -18,16 +18,17 @@ internal data class PaymentIntentDomainEntity(
     val isPreAuthPayment: Boolean = false,
     val orderId: String = "",
     val collectionShippingAddressRequired: Boolean = false,
-    val merchantName: String = ""
+    val isSetUpIntentPayment: Boolean = false,
+    val merchantName: String = "",
 )
 
 data class AmountDomainEntity(
     val valueLong: Long,
     val valueString: String,
-    val currencyCode: String
+    val currencyCode: String,
 )
 
 internal data class ItemLinesDomainEntity(
     val caption: String,
-    val amount: Amount
+    val amount: Amount,
 )

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
@@ -17,7 +17,7 @@ internal class PaymentIntentDomainEntityMapper {
             amount = AmountDomainEntity(
                 valueLong = requireNotNull(raw.amount?.value),
                 valueString = requireNotNull(raw.amount?.value?.centsToString()),
-                currencyCode = requireNotNull(raw.amount?.currencyCode)
+                currencyCode = requireNotNull(raw.amount?.currencyCode),
             ),
             supportedCardsSchemes = requireNotNull(raw.merchantConfig?.supportedPaymentMethods?.cardSchemes?.mapNotNull { it }),
             supportedWalletSchemes = raw.merchantConfig?.supportedPaymentMethods?.wallets
@@ -25,7 +25,7 @@ internal class PaymentIntentDomainEntityMapper {
             itemLines = raw.itemLines?.map {
                 ItemLinesDomainEntity(
                     amount = it.amountTotal,
-                    caption = it.caption
+                    caption = it.caption,
                 )
             },
             collectionEmailRequired = raw.config?.customerEmail?.collectionRequired ?: false,
@@ -36,7 +36,8 @@ internal class PaymentIntentDomainEntityMapper {
             isVirtualTerminalPayment = raw.paymentSource?.let { it.lowercase() == "virtual-terminal" } ?: false,
             isPreAuthPayment = raw.captureMode?.let { it.lowercase() == "manual" } ?: false,
             orderId = raw.reference ?: "",
-            merchantName = raw.config?.tradingName ?: ""
+            isSetUpIntentPayment = !raw.merchantInitiatedType.isNullOrBlank() && !raw.setupSource.isNullOrBlank(),
+            merchantName = raw.config?.tradingName ?: "",
         )
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
@@ -36,7 +36,7 @@ internal class PaymentIntentDomainEntityMapper {
             isVirtualTerminalPayment = raw.paymentSource?.let { it.lowercase() == "virtual-terminal" } ?: false,
             isPreAuthPayment = raw.captureMode?.let { it.lowercase() == "manual" } ?: false,
             orderId = raw.reference ?: "",
-            isSetUpIntentPayment = !raw.merchantInitiatedType.isNullOrBlank() && !raw.setupSource.isNullOrBlank(),
+            isSetUpIntentPayment = !raw.merchantInitiatedType.isNullOrBlank() && !raw.paymentSource.isNullOrBlank(),
             merchantName = raw.config?.tradingName ?: "",
         )
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
@@ -15,9 +15,9 @@ internal class PaymentIntentDomainEntityMapper {
             customerId = raw.customer?.id,
             paymentToken = requireNotNull(raw.clientSessionSecret),
             amount = AmountDomainEntity(
-                valueLong = requireNotNull(raw.amount?.value),
-                valueString = requireNotNull(raw.amount?.value?.centsToString()),
-                currencyCode = requireNotNull(raw.amount?.currencyCode),
+                valueLong = requireNotNull(raw.amount?.value ?: raw.intendedAmount?.value),
+                valueString = requireNotNull(raw.amount?.value?.centsToString() ?: raw.intendedAmount?.value?.centsToString()),
+                currencyCode = requireNotNull(raw.amount?.currencyCode ?: raw.intendedAmount?.currencyCode),
             ),
             supportedCardsSchemes = requireNotNull(raw.merchantConfig?.supportedPaymentMethods?.cardSchemes?.mapNotNull { it }),
             supportedWalletSchemes = raw.merchantConfig?.supportedPaymentMethods?.wallets
@@ -45,7 +45,7 @@ internal class PaymentIntentDomainEntityMapper {
         val invalidParams: MutableList<String> = mutableListOf()
         if (raw.id == null) invalidParams.add("id")
         if (raw.clientSessionSecret == null) invalidParams.add("clientSessionSecret")
-        if (raw.amount == null) invalidParams.add("amount")
+        if (raw.amount == null && raw.intendedAmount == null) invalidParams.add("amount")
         if (raw.merchantConfig == null) invalidParams.add("merchantConfig")
         if (raw.merchantConfig?.supportedPaymentMethods == null) invalidParams.add("supportedPaymentMethods")
         if (raw.merchantConfig?.supportedPaymentMethods?.cardSchemes == null) invalidParams.add("cardSchemes")

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoPaymentType.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoPaymentType.kt
@@ -4,6 +4,6 @@ import java.io.Serializable
 
 enum class DojoPaymentType : Serializable {
     PAYMENT_CARD,
-    CARD_ON_FILE,
+    SETUP_INTENT,
     VIRTUAL_TERMINAL,
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -301,9 +301,10 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         composable(route = PaymentFlowScreens.CardDetailsCheckout.route) {
             val cardDetailsCheckoutViewModel: CardDetailsCheckoutViewModel by viewModels {
                 CardDetailsCheckoutViewModelFactory(
-                    cardPaymentHandler,
-                    isDarkModeEnabled,
-                    this@PaymentFlowContainerActivity,
+                    dojoCardPaymentHandler = cardPaymentHandler,
+                    isDarkModeEnabled = isDarkModeEnabled,
+                    context = this@PaymentFlowContainerActivity,
+                    isStartDestination = flowStartDestination == PaymentFlowScreens.CardDetailsCheckout,
                 )
             }
             // this is to handle unregistered activity when screen orientation change

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -14,7 +14,6 @@ import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
 import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.entities.DarkColorPalette
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
-import tech.dojo.pay.uisdk.entities.DojoPaymentType.*
 import tech.dojo.pay.uisdk.entities.LightColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.darkColorPalette
 import tech.dojo.pay.uisdk.presentation.components.theme.lightColorPalette
@@ -77,7 +76,7 @@ internal class PaymentFlowViewModel(
         )
         if (isInitCorrectly) {
             currentCustomerId = paymentIntentResult.result.customerId
-            if (paymentType == PAYMENT_CARD) {
+            if (paymentType == DojoPaymentType.PAYMENT_CARD) {
                 fetchPaymentMethodsUseCase.fetchPaymentMethodsWithPaymentType(
                     paymentType,
                     paymentIntentResult.result.customerId ?: "",
@@ -142,9 +141,9 @@ internal class PaymentFlowViewModel(
 
     fun getFlowStartDestination(): PaymentFlowScreens {
         return when (paymentType) {
-            PAYMENT_CARD -> PaymentFlowScreens.PaymentMethodCheckout
-            SETUP_INTENT -> PaymentFlowScreens.CardDetailsCheckout
-            VIRTUAL_TERMINAL -> PaymentFlowScreens.VirtualTerminalCheckOutScreen
+            DojoPaymentType.PAYMENT_CARD -> PaymentFlowScreens.PaymentMethodCheckout
+            DojoPaymentType.SETUP_INTENT -> PaymentFlowScreens.CardDetailsCheckout
+            DojoPaymentType.VIRTUAL_TERMINAL -> PaymentFlowScreens.VirtualTerminalCheckOutScreen
         }
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -77,12 +77,14 @@ internal class PaymentFlowViewModel(
         )
         if (isInitCorrectly) {
             currentCustomerId = paymentIntentResult.result.customerId
-            fetchPaymentMethodsUseCase.fetchPaymentMethodsWithPaymentType(
-                paymentType,
-                paymentIntentResult.result.customerId ?: "",
-                customerSecret,
+            if (paymentType == PAYMENT_CARD) {
+                fetchPaymentMethodsUseCase.fetchPaymentMethodsWithPaymentType(
+                    paymentType,
+                    paymentIntentResult.result.customerId ?: "",
+                    customerSecret,
 
-            )
+                )
+            }
         } else {
             closeFlowWithInternalError()
         }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelFactory.kt
@@ -9,6 +9,7 @@ import tech.dojo.pay.uisdk.data.paymentintent.PaymentIntentRepository
 import tech.dojo.pay.uisdk.data.paymentmethods.PaymentMethodsRepository
 import tech.dojo.pay.uisdk.domain.FetchPaymentIntentUseCase
 import tech.dojo.pay.uisdk.domain.FetchPaymentMethodsUseCase
+import tech.dojo.pay.uisdk.domain.IsSDKInitializedCorrectlyUseCase
 import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
 import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.entities.DojoPaymentFlowParams
@@ -37,6 +38,7 @@ internal class PaymentFlowViewModelFactory(private val arguments: Bundle?) :
         val updatePaymentStateUseCase = UpdatePaymentStateUseCase(paymentStatusRepository)
         val fetchPaymentMethodsUseCase =
             FetchPaymentMethodsUseCase(paymentMethodsRepository)
+        val isSDKInitializedCorrectlyUseCase = IsSDKInitializedCorrectlyUseCase()
         return PaymentFlowViewModel(
             paymentId,
             customerSecret,
@@ -45,6 +47,7 @@ internal class PaymentFlowViewModelFactory(private val arguments: Bundle?) :
             observePaymentIntent,
             fetchPaymentMethodsUseCase,
             updatePaymentStateUseCase,
+            isSDKInitializedCorrectlyUseCase,
         ) as T
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/AmountWithPaymentMethoudsHeader.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/AmountWithPaymentMethoudsHeader.kt
@@ -25,7 +25,7 @@ internal fun HeaderItem(
     modifier: Modifier = Modifier,
     amount: String,
     currencyLogo: String,
-    allowedPaymentMethodsIcons: List<Int>
+    allowedPaymentMethodsIcons: List<Int>,
 ) {
     Box(modifier = modifier) {
         Column(
@@ -40,7 +40,7 @@ internal fun HeaderItem(
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
                 style = DojoTheme.typography.h6.medium,
-                color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high)
+                color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high),
             )
 
             Row(
@@ -48,7 +48,7 @@ internal fun HeaderItem(
                     .fillMaxWidth()
                     .heightIn(min = 30.dp),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
+                horizontalArrangement = Arrangement.Center,
 
             ) {
                 Text(
@@ -56,20 +56,20 @@ internal fun HeaderItem(
                         start = 0.dp,
                         top = 12.dp,
                         bottom = 2.dp,
-                        end = 8.dp
+                        end = 8.dp,
                     ),
                     text = currencyLogo,
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                     style = DojoTheme.typography.h3.medium,
-                    color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high)
+                    color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high),
                 )
                 Text(
                     text = amount,
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
                     style = DojoTheme.typography.h1.medium,
-                    color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high)
+                    color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high),
                 )
             }
             SupportedPaymentMethods(Modifier.padding(top = 16.dp), allowedPaymentMethodsIcons)
@@ -79,6 +79,6 @@ internal fun HeaderItem(
 
 @Preview("AmountBanner", group = "Footer")
 @Composable
-private fun PreviewAmountBanner() = DojoPreview {
+internal fun PreviewAmountBanner() = DojoPreview {
     HeaderItem(amount = "95.70", currencyLogo = "£", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/AmountWithPaymentMethoudsHeader.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/AmountWithPaymentMethoudsHeader.kt
@@ -79,6 +79,6 @@ internal fun HeaderItem(
 
 @Preview("AmountBanner", group = "Footer")
 @Composable
-internal fun PreviewAmountBanner() = DojoPreview {
+private fun PreviewAmountBanner() = DojoPreview {
     HeaderItem(amount = "95.70", currencyLogo = "£", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/AmountWithPaymentMethoudsHeader.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/AmountWithPaymentMethoudsHeader.kt
@@ -21,7 +21,7 @@ import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.components.theme.medium
 
 @Composable
-internal fun AmountWithPaymentMethodsHeader(
+internal fun HeaderItem(
     modifier: Modifier = Modifier,
     amount: String,
     currencyLogo: String,
@@ -80,5 +80,5 @@ internal fun AmountWithPaymentMethodsHeader(
 @Preview("AmountBanner", group = "Footer")
 @Composable
 internal fun PreviewAmountBanner() = DojoPreview {
-    AmountWithPaymentMethodsHeader(amount = "95.70", currencyLogo = "£", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
+    HeaderItem(amount = "95.70", currencyLogo = "£", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/CheckBoxItem.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/CheckBoxItem.kt
@@ -30,7 +30,6 @@ internal fun CheckBoxItem(
     onCheckedChange: (Boolean) -> Unit,
 ) {
     val checkedState = remember { mutableStateOf(isChecked) }
-
     Row(
         modifier = modifier
             .fillMaxWidth()

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/CheckBoxItem.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/CheckBoxItem.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -26,50 +28,52 @@ import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 internal fun CheckBoxItem(
     modifier: Modifier = Modifier,
     itemText: String,
-    onCheckedChange: (Boolean) -> (Unit),
+    onCheckedChange: (Boolean) -> Unit,
 ) {
     val checkedState = remember { mutableStateOf(true) }
-    Box(modifier = modifier) {
-        Row(
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable {
+                checkedState.value = !checkedState.value
+                onCheckedChange(checkedState.value)
+            },
+        verticalAlignment = Alignment.Top,
+    ) {
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .height(30.dp),
-            verticalAlignment = Alignment.CenterVertically
-
+                .width(25.dp)
+                .height(30.dp)
+                .padding(vertical = 4.dp)
+                .border(
+                    width = 1.dp,
+                    color = if (checkedState.value) DojoTheme.colors.inputElementActiveTintColor else DojoTheme.colors.inputElementDefaultTintColor,
+                    shape = DojoTheme.shapes.small,
+                )
+                .background(DojoTheme.colors.primarySurfaceBackgroundColor),
+            contentAlignment = Alignment.Center,
         ) {
-            Box(
-                modifier = Modifier
-                    .size(25.dp)
-                    .border(
-                        width = 1.dp,
-                        color = if (checkedState.value) DojoTheme.colors.inputElementActiveTintColor else DojoTheme.colors.inputElementDefaultTintColor,
-                        shape = DojoTheme.shapes.small
-                    )
-                    .background(DojoTheme.colors.primarySurfaceBackgroundColor)
-                    .clickable {
-                        checkedState.value = !checkedState.value
-                        onCheckedChange(checkedState.value)
-                    },
-                contentAlignment = Alignment.Center
-            ) {
-                if (checkedState.value) {
-                    Icon(
-                        Icons.Default.Check,
-                        contentDescription = "",
-                        tint = DojoTheme.colors.inputElementActiveTintColor
-                    )
-                }
+            if (checkedState.value) {
+                Icon(
+                    Icons.Default.Check,
+                    contentDescription = "",
+                    tint = DojoTheme.colors.inputElementActiveTintColor,
+                )
             }
-            DojoSpacer(16.dp)
-
-            Text(
-                text = itemText,
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                color = DojoTheme.colors.secondaryLabelTextColor,
-                style = DojoTheme.typography.subtitle1
-            )
         }
+        DojoSpacer(width = 12.dp)
+        Text(
+            text = itemText,
+            modifier = Modifier
+                .weight(1f)
+                .wrapContentHeight(),
+            overflow = TextOverflow.Ellipsis,
+            softWrap = true,
+            maxLines = 4,
+            color = DojoTheme.colors.secondaryLabelTextColor,
+            style = DojoTheme.typography.subtitle1,
+        )
     }
 }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/CheckBoxItem.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/CheckBoxItem.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
@@ -28,9 +26,10 @@ import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 internal fun CheckBoxItem(
     modifier: Modifier = Modifier,
     itemText: String,
+    isChecked: Boolean = true,
     onCheckedChange: (Boolean) -> Unit,
 ) {
-    val checkedState = remember { mutableStateOf(true) }
+    val checkedState = remember { mutableStateOf(isChecked) }
 
     Row(
         modifier = modifier
@@ -39,20 +38,18 @@ internal fun CheckBoxItem(
                 checkedState.value = !checkedState.value
                 onCheckedChange(checkedState.value)
             },
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
             modifier = Modifier
-                .width(25.dp)
-                .height(30.dp)
-                .padding(vertical = 4.dp)
+                .size(25.dp)
                 .border(
                     width = 1.dp,
                     color = if (checkedState.value) DojoTheme.colors.inputElementActiveTintColor else DojoTheme.colors.inputElementDefaultTintColor,
                     shape = DojoTheme.shapes.small,
                 )
-                .background(DojoTheme.colors.primarySurfaceBackgroundColor),
-            contentAlignment = Alignment.Center,
+                .background(DojoTheme.colors.primarySurfaceBackgroundColor)
+                .align(Alignment.Top),
         ) {
             if (checkedState.value) {
                 Icon(
@@ -63,17 +60,21 @@ internal fun CheckBoxItem(
             }
         }
         DojoSpacer(width = 12.dp)
-        Text(
-            text = itemText,
+        Box(
             modifier = Modifier
                 .weight(1f)
-                .wrapContentHeight(),
-            overflow = TextOverflow.Ellipsis,
-            softWrap = true,
-            maxLines = 4,
-            color = DojoTheme.colors.secondaryLabelTextColor,
-            style = DojoTheme.typography.subtitle1,
-        )
+                .wrapContentHeight()
+                .align(Alignment.Top),
+        ) {
+            Text(
+                text = itemText,
+                overflow = TextOverflow.Ellipsis,
+                softWrap = true,
+                maxLines = 7,
+                color = DojoTheme.colors.secondaryLabelTextColor,
+                style = DojoTheme.typography.subtitle1,
+            )
+        }
     }
 }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/MerchantIInfoWhithSupportedNetwrokdsHeader.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/MerchantIInfoWhithSupportedNetwrokdsHeader.kt
@@ -52,8 +52,15 @@ internal fun MerchantInfoWithSupportedNetworksHeader(
     }
 }
 
-@Preview("MerchantIInfoWithSupportedNetworksHeader", group = "MerchantIInfoWithSupportedNetworksHeader")
+@Preview(
+    "MerchantInfoWithSupportedNetworksHeader",
+    group = "MerchantInfoWithSupportedNetworksHeader",
+)
 @Composable
-private fun PreviewMerchantIInfoWithSupportedNetworksHeader() = DojoPreview {
-    MerchantInfoWithSupportedNetworksHeader(merchantName = "El pastor", orderId = "12312312", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
+private fun PreviewMerchantInfoWithSupportedNetworksHeader() = DojoPreview {
+    MerchantInfoWithSupportedNetworksHeader(
+        merchantName = "El pastor",
+        orderId = "12312312",
+        allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex),
+    )
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/MerchantIInfoWhithSupportedNetwrokdsHeader.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/MerchantIInfoWhithSupportedNetwrokdsHeader.kt
@@ -19,7 +19,7 @@ import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.components.theme.medium
 
 @Composable
-internal fun MerchantIInfoWithSupportedNetworksHeader(
+internal fun MerchantInfoWithSupportedNetworksHeader(
     modifier: Modifier = Modifier,
     merchantName: String,
     orderId: String,
@@ -54,6 +54,6 @@ internal fun MerchantIInfoWithSupportedNetworksHeader(
 
 @Preview("MerchantIInfoWithSupportedNetworksHeader", group = "MerchantIInfoWithSupportedNetworksHeader")
 @Composable
-internal fun PreviewMerchantIInfoWithSupportedNetworksHeader() = DojoPreview {
-    MerchantIInfoWithSupportedNetworksHeader(merchantName = "El pastor", orderId = "12312312", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
+private fun PreviewMerchantIInfoWithSupportedNetworksHeader() = DojoPreview {
+    MerchantInfoWithSupportedNetworksHeader(merchantName = "El pastor", orderId = "12312312", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/MerchantIInfoWhithSupportedNetwrokdsHeader.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/MerchantIInfoWhithSupportedNetwrokdsHeader.kt
@@ -1,0 +1,59 @@
+package tech.dojo.pay.uisdk.presentation.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import tech.dojo.pay.uisdk.R
+import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
+import tech.dojo.pay.uisdk.presentation.components.theme.medium
+
+@Composable
+internal fun MerchantIInfoWithSupportedNetworksHeader(
+    modifier: Modifier = Modifier,
+    merchantName: String,
+    orderId: String,
+    allowedPaymentMethodsIcons: List<Int>,
+) {
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 40.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = merchantName,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                style = DojoTheme.typography.h3.medium,
+                color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high),
+            )
+            Text(
+                text = orderId,
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+                style = DojoTheme.typography.body1,
+                color = DojoTheme.colors.primaryLabelTextColor.copy(alpha = ContentAlpha.high),
+            )
+            SupportedPaymentMethods(Modifier.padding(top = 16.dp), allowedPaymentMethodsIcons)
+        }
+    }
+}
+
+@Preview("MerchantIInfoWithSupportedNetworksHeader", group = "MerchantIInfoWithSupportedNetworksHeader")
+@Composable
+internal fun PreviewMerchantIInfoWithSupportedNetworksHeader() = DojoPreview {
+    MerchantIInfoWithSupportedNetworksHeader(merchantName = "El pastor", orderId = "12312312", allowedPaymentMethodsIcons = listOf(R.drawable.ic_amex))
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -232,10 +232,10 @@ private fun PayButton(
     SingleButtonView(
         scrollState = scrollState,
         text = stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_button_pay) + " " + state.amountCurrency + " " + state.totalAmount,
-        isLoading = state.isLoading,
-        enabled = state.isEnabled
+        isLoading = state.actionButtonState.isLoading,
+        enabled = state.actionButtonState.isEnabled
     ) {
-        if (!state.isLoading) {
+        if (!state.actionButtonState.isLoading) {
             focusManager.clearFocus()
             viewModel.onPayWithCardClicked()
         }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -213,7 +213,7 @@ private fun SaveCardCheckBox(
 ) {
     if (state.checkBoxItem.isVisible) {
         CheckBoxItem(
-            itemText = stringResource(id = state.checkBoxItem.messageText),
+            itemText = state.checkBoxItem.messageText,
             onCheckedChange = {
                 viewModel.onSaveCardChecked(it)
             }
@@ -231,7 +231,7 @@ private fun PayButton(
     val focusManager = LocalFocusManager.current
     SingleButtonView(
         scrollState = scrollState,
-        text = stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_button_pay) + " " + state.amountCurrency + " " + state.totalAmount,
+        text = state.actionButtonState.text,
         isLoading = state.actionButtonState.isLoading,
         enabled = state.actionButtonState.isEnabled
     ) {
@@ -277,9 +277,7 @@ private fun CvvField(
         label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_cvv)) },
         cvvValue = state.cvvInputFieldState.value,
         isError = state.cvvInputFieldState.isError,
-        assistiveText = state.cvvInputFieldState.errorMessages?.let {
-            AnnotatedString(stringResource(id = it))
-        },
+        assistiveText = state.cvvInputFieldState.errorMessages?.let { AnnotatedString(it) },
         keyboardActions = KeyboardActions(onDone = {
             keyboardController?.hide()
         }),
@@ -331,9 +329,7 @@ private fun CardExpireDateField(
             keyboardController?.hide()
         }),
         isError = state.cardExpireDateInputField.isError,
-        assistiveText = state.cardExpireDateInputField.errorMessages?.let {
-            AnnotatedString(stringResource(id = it))
-        },
+        assistiveText = state.cardExpireDateInputField.errorMessages?.let { AnnotatedString(it) },
         expireDateValue = state.cardExpireDateInputField.value,
         expireDaterPlaceholder = stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_expiry),
         onExpireDateValueChanged = { viewModel.onExpireDateValueChanged(it) }
@@ -386,9 +382,7 @@ private fun CardNumberField(
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
         isError = state.cardNumberInputField.isError,
         assistiveText = state.cardNumberInputField.errorMessages?.let {
-            AnnotatedString(
-                stringResource(id = it)
-            )
+            AnnotatedString(it)
         },
         cardNumberValue = state.cardNumberInputField.value,
         cardNumberPlaceholder = stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_pan),
@@ -428,11 +422,7 @@ private fun CardHolderNameField(
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
         value = state.cardHolderInputField.value,
         isError = state.cardHolderInputField.isError,
-        assistiveText = state.cardHolderInputField.errorMessages?.let {
-            AnnotatedString(
-                stringResource(id = it)
-            )
-        },
+        assistiveText = state.cardHolderInputField.errorMessages?.let { AnnotatedString(it) },
         onValueChange = { viewModel.onCardHolderValueChanged(it) },
         label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_field_card_name)) }
     )
@@ -471,9 +461,7 @@ private fun EmailField(
                 },
             isError = state.emailInputField.isError,
             assistiveText = state.emailInputField.errorMessages?.let {
-                AnnotatedString(
-                    stringResource(id = it)
-                )
+                AnnotatedString(it)
             },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
@@ -529,7 +517,7 @@ private fun PostalCodeField(
             value = state.postalCodeField.value,
             isError = state.postalCodeField.isError,
             assistiveText =
-            state.postalCodeField.errorMessages?.let { AnnotatedString(stringResource(id = it)) },
+            state.postalCodeField.errorMessages?.let { AnnotatedString(it) },
             onValueChange = { viewModel.onPostalCodeValueChanged(it) },
             label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_billing_postcode)) }
         )

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -88,7 +88,7 @@ internal fun CardDetailsCheckoutScreen(
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         backgroundColor = DojoTheme.colors.primarySurfaceBackgroundColor,
-        topBar = { AppBarItem(onBackClicked, onCloseClicked) },
+        topBar = { AppBarItem(onBackClicked, onCloseClicked, state.toolbarTitle) },
         content = {
             Column(
                 modifier = Modifier
@@ -573,9 +573,9 @@ private fun HeaderItem(state: CardDetailsCheckoutState) {
 }
 
 @Composable
-private fun AppBarItem(onBackClicked: () -> Unit, onCloseClicked: () -> Unit) {
+private fun AppBarItem(onBackClicked: () -> Unit, onCloseClicked: () -> Unit, toolbarTitle: String?) {
     DojoAppBar(
-        title = stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_title),
+        title = toolbarTitle?:stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_title),
         titleGravity = TitleGravity.LEFT,
         navigationIcon = AppBarIcon.back(DojoTheme.colors.headerButtonTintColor) { onBackClicked() },
         actionIcon = AppBarIcon.close(DojoTheme.colors.headerButtonTintColor) { onCloseClicked() },

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -211,9 +211,9 @@ private fun SaveCardCheckBox(
     state: CardDetailsCheckoutState,
     viewModel: CardDetailsCheckoutViewModel
 ) {
-    if (state.saveCardCheckBox.isVisible) {
+    if (state.checkBoxItem.isVisible) {
         CheckBoxItem(
-            itemText = stringResource(id = state.saveCardCheckBox.messageText),
+            itemText = stringResource(id = state.checkBoxItem.messageText),
             onCheckedChange = {
                 viewModel.onSaveCardChecked(it)
             }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -48,7 +48,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import tech.dojo.pay.uisdk.R
-import tech.dojo.pay.uisdk.presentation.components.AmountWithPaymentMethodsHeader
 import tech.dojo.pay.uisdk.presentation.components.AppBarIcon
 import tech.dojo.pay.uisdk.presentation.components.CardExpireDateInputField
 import tech.dojo.pay.uisdk.presentation.components.CardNumberInPutField
@@ -58,14 +57,18 @@ import tech.dojo.pay.uisdk.presentation.components.CvvInputField
 import tech.dojo.pay.uisdk.presentation.components.DojoAppBar
 import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooter
 import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooterModes
+import tech.dojo.pay.uisdk.presentation.components.HeaderItem
 import tech.dojo.pay.uisdk.presentation.components.InputFieldWithErrorMessage
+import tech.dojo.pay.uisdk.presentation.components.MerchantIInfoWithSupportedNetworksHeader
 import tech.dojo.pay.uisdk.presentation.components.SingleButtonView
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardCheckOutHeaderType
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.viewmodel.CardDetailsCheckoutViewModel
 import kotlin.math.roundToInt
+
 @Suppress("LongMethod")
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -92,13 +95,13 @@ internal fun CardDetailsCheckoutScreen(
                     .fillMaxWidth()
                     .heightIn(min = 40.dp),
                 verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxHeight()
                         .fillMaxWidth(fraction = if (windowSize.widthWindowType == WindowSize.WindowType.COMPACT) 1f else .6f)
-                        .padding(it)
+                        .padding(it),
                 ) {
                     Column(
                         Modifier
@@ -110,20 +113,20 @@ internal fun CardDetailsCheckoutScreen(
                             }
                             .imePadding()
                             .padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 150.dp),
-                        verticalArrangement = Arrangement.spacedBy(32.dp)
+                        verticalArrangement = Arrangement.spacedBy(32.dp),
                     ) {
-                        AmountWithPaymentMethodsHeader(state)
+                        HeaderItem(state)
                         EmailField(
                             scrollState,
                             coroutineScope,
                             scrollToPosition,
                             state,
                             keyboardController,
-                            viewModel
+                            viewModel,
                         )
                         BillingCountryField(
                             state,
-                            viewModel
+                            viewModel,
                         )
                         PostalCodeField(
                             scrollState,
@@ -131,7 +134,7 @@ internal fun CardDetailsCheckoutScreen(
                             scrollToPosition,
                             state,
                             keyboardController,
-                            viewModel
+                            viewModel,
                         )
                         CardHolderNameField(
                             scrollState,
@@ -139,7 +142,7 @@ internal fun CardDetailsCheckoutScreen(
                             scrollToPosition,
                             keyboardController,
                             state,
-                            viewModel
+                            viewModel,
                         )
                         CardNumberField(
                             scrollState,
@@ -148,15 +151,15 @@ internal fun CardDetailsCheckoutScreen(
                             keyboardController,
                             state,
                             viewModel,
-                            isDarkModeEnabled
+                            isDarkModeEnabled,
                         )
                         Row(
                             modifier = Modifier
                                 .align(Alignment.CenterHorizontally)
-                                .heightIn(48.dp)
+                                .heightIn(48.dp),
                         ) {
                             Box(
-                                modifier = Modifier.weight(1f)
+                                modifier = Modifier.weight(1f),
                             ) {
                                 CardExpireDateField(
                                     scrollState,
@@ -164,7 +167,7 @@ internal fun CardDetailsCheckoutScreen(
                                     scrollToPosition,
                                     keyboardController,
                                     state,
-                                    viewModel
+                                    viewModel,
                                 )
                             }
 
@@ -176,7 +179,7 @@ internal fun CardDetailsCheckoutScreen(
                                     scrollToPosition,
                                     state,
                                     keyboardController,
-                                    viewModel
+                                    viewModel,
                                 )
                             }
                         }
@@ -187,14 +190,14 @@ internal fun CardDetailsCheckoutScreen(
                         verticalArrangement = Arrangement.spacedBy(0.dp),
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
-                            .background(DojoTheme.colors.primarySurfaceBackgroundColor)
+                            .background(DojoTheme.colors.primarySurfaceBackgroundColor),
                     ) {
                         PayButton(scrollState, state, viewModel)
                         ScreenFooter(showDojoBrand)
                     }
                 }
             }
-        }
+        },
     )
 }
 
@@ -202,21 +205,21 @@ internal fun CardDetailsCheckoutScreen(
 private fun ScreenFooter(showDojoBrand: Boolean) {
     DojoBrandFooter(
         modifier = Modifier.padding(bottom = 24.dp),
-        mode = if (showDojoBrand) DojoBrandFooterModes.DOJO_BRAND_WITH_TERMS_AND_PRIVACY else DojoBrandFooterModes.TERMS_AND_PRIVACY_ONLY
+        mode = if (showDojoBrand) DojoBrandFooterModes.DOJO_BRAND_WITH_TERMS_AND_PRIVACY else DojoBrandFooterModes.TERMS_AND_PRIVACY_ONLY,
     )
 }
 
 @Composable
 private fun SaveCardCheckBox(
     state: CardDetailsCheckoutState,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     if (state.checkBoxItem.isVisible) {
         CheckBoxItem(
             itemText = state.checkBoxItem.messageText,
             onCheckedChange = {
                 viewModel.onSaveCardChecked(it)
-            }
+            },
         )
     }
 }
@@ -226,14 +229,14 @@ private fun SaveCardCheckBox(
 private fun PayButton(
     scrollState: ScrollState,
     state: CardDetailsCheckoutState,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     val focusManager = LocalFocusManager.current
     SingleButtonView(
         scrollState = scrollState,
         text = state.actionButtonState.text,
         isLoading = state.actionButtonState.isLoading,
-        enabled = state.actionButtonState.isEnabled
+        enabled = state.actionButtonState.isEnabled,
     ) {
         if (!state.actionButtonState.isLoading) {
             focusManager.clearFocus()
@@ -250,12 +253,16 @@ private fun CvvField(
     scrollToPosition: Float,
     state: CardDetailsCheckoutState,
     keyboardController: SoftwareKeyboardController?,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     val scrollOffset = with(LocalDensity.current) {
-        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) FIFTH_FIELD_OFF_SET_DP.dp.toPx()
-        else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) FORTH_FIELD_OFF_SET_DP.dp.toPx()
-        else THIRD_FIELD_OFF_SET_DP.dp.toPx()
+        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) {
+            FIFTH_FIELD_OFF_SET_DP.dp.toPx()
+        } else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) {
+            FORTH_FIELD_OFF_SET_DP.dp.toPx()
+        } else {
+            THIRD_FIELD_OFF_SET_DP.dp.toPx()
+        }
     }
 
     CvvInputField(
@@ -265,13 +272,13 @@ private fun CvvField(
                     coroutineScope.launch {
                         delay(300)
                         scrollState.animateScrollTo(
-                            scrollToPosition.roundToInt() + scrollOffset.roundToInt()
+                            scrollToPosition.roundToInt() + scrollOffset.roundToInt(),
                         )
                     }
                 }
                 viewModel.validateCvv(
                     state.cvvInputFieldState.value,
-                    it.isFocused
+                    it.isFocused,
                 )
             },
         label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_cvv)) },
@@ -282,7 +289,7 @@ private fun CvvField(
             keyboardController?.hide()
         }),
         cvvPlaceholder = stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_cvv),
-        onCvvValueChanged = { viewModel.onCvvValueChanged(it) }
+        onCvvValueChanged = { viewModel.onCvvValueChanged(it) },
     )
 }
 
@@ -294,12 +301,16 @@ private fun CardExpireDateField(
     scrollToPosition: Float,
     keyboardController: SoftwareKeyboardController?,
     state: CardDetailsCheckoutState,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     val scrollOffset = with(LocalDensity.current) {
-        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) FIFTH_FIELD_OFF_SET_DP.dp.toPx()
-        else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) FORTH_FIELD_OFF_SET_DP.dp.toPx()
-        else THIRD_FIELD_OFF_SET_DP.dp.toPx()
+        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) {
+            FIFTH_FIELD_OFF_SET_DP.dp.toPx()
+        } else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) {
+            FORTH_FIELD_OFF_SET_DP.dp.toPx()
+        } else {
+            THIRD_FIELD_OFF_SET_DP.dp.toPx()
+        }
     }
 
     CardExpireDateInputField(
@@ -310,20 +321,20 @@ private fun CardExpireDateField(
                     coroutineScope.launch {
                         delay(300)
                         scrollState.animateScrollTo(
-                            scrollToPosition.roundToInt() + scrollOffset.roundToInt()
+                            scrollToPosition.roundToInt() + scrollOffset.roundToInt(),
                         )
                     }
                 }
                 viewModel.validateExpireDate(
                     state.cardExpireDateInputField.value,
-                    it.isFocused
+                    it.isFocused,
                 )
             },
         label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_expiry_date)) },
         keyboardOptions =
         KeyboardOptions(
             keyboardType = KeyboardType.Number,
-            imeAction = ImeAction.Done
+            imeAction = ImeAction.Done,
         ),
         keyboardActions = KeyboardActions(onDone = {
             keyboardController?.hide()
@@ -332,7 +343,7 @@ private fun CardExpireDateField(
         assistiveText = state.cardExpireDateInputField.errorMessages?.let { AnnotatedString(it) },
         expireDateValue = state.cardExpireDateInputField.value,
         expireDaterPlaceholder = stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_expiry),
-        onExpireDateValueChanged = { viewModel.onExpireDateValueChanged(it) }
+        onExpireDateValueChanged = { viewModel.onExpireDateValueChanged(it) },
     )
 }
 
@@ -345,12 +356,16 @@ private fun CardNumberField(
     keyboardController: SoftwareKeyboardController?,
     state: CardDetailsCheckoutState,
     viewModel: CardDetailsCheckoutViewModel,
-    isDarkModeEnabled: Boolean
+    isDarkModeEnabled: Boolean,
 ) {
     val scrollOffset = with(LocalDensity.current) {
-        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) FORTH_FIELD_OFF_SET_DP.dp.toPx()
-        else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) THIRD_FIELD_OFF_SET_DP.dp.toPx()
-        else SECOND_FIELD_OFF_SET_DP.dp.toPx()
+        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) {
+            FORTH_FIELD_OFF_SET_DP.dp.toPx()
+        } else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) {
+            THIRD_FIELD_OFF_SET_DP.dp.toPx()
+        } else {
+            SECOND_FIELD_OFF_SET_DP.dp.toPx()
+        }
     }
     var focusedTextKey by remember { mutableStateOf(false) }
 
@@ -360,14 +375,16 @@ private fun CardNumberField(
                 coroutineScope.launch {
                     delay(300)
                     scrollState.animateScrollTo(
-                        scrollToPosition.roundToInt() + scrollOffset.roundToInt()
+                        scrollToPosition.roundToInt() + scrollOffset.roundToInt(),
                     )
                 }
             }
-            focusedTextKey = if (it.isFocused) { true } else {
+            focusedTextKey = if (it.isFocused) {
+                true
+            } else {
                 if (focusedTextKey) {
                     viewModel.validateCardNumber(
-                        state.cardNumberInputField.value
+                        state.cardNumberInputField.value,
                     )
                 }
                 false
@@ -377,7 +394,7 @@ private fun CardNumberField(
         keyboardOptions =
         KeyboardOptions(
             keyboardType = KeyboardType.Number,
-            imeAction = ImeAction.Done
+            imeAction = ImeAction.Done,
         ),
         keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
         isError = state.cardNumberInputField.isError,
@@ -387,7 +404,7 @@ private fun CardNumberField(
         cardNumberValue = state.cardNumberInputField.value,
         cardNumberPlaceholder = stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_pan),
         onCardNumberValueChanged = { viewModel.onCardNumberValueChanged(it) },
-        isDarkModeEnabled = isDarkModeEnabled
+        isDarkModeEnabled = isDarkModeEnabled,
     )
 }
 
@@ -399,12 +416,16 @@ private fun CardHolderNameField(
     scrollToPosition: Float,
     keyboardController: SoftwareKeyboardController?,
     state: CardDetailsCheckoutState,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     val scrollOffset = with(LocalDensity.current) {
-        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) THIRD_FIELD_OFF_SET_DP.dp.toPx()
-        else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) SECOND_FIELD_OFF_SET_DP.dp.toPx()
-        else FIRST_FIELD_OFF_SET_DP.dp.toPx()
+        if (state.isEmailInputFieldRequired && state.isPostalCodeFieldRequired) {
+            THIRD_FIELD_OFF_SET_DP.dp.toPx()
+        } else if (state.isPostalCodeFieldRequired || state.isEmailInputFieldRequired) {
+            SECOND_FIELD_OFF_SET_DP.dp.toPx()
+        } else {
+            FIRST_FIELD_OFF_SET_DP.dp.toPx()
+        }
     }
 
     InputFieldWithErrorMessage(
@@ -413,7 +434,7 @@ private fun CardHolderNameField(
                 coroutineScope.launch {
                     delay(300)
                     scrollState.animateScrollTo(
-                        scrollToPosition.roundToInt() + scrollOffset.roundToInt()
+                        scrollToPosition.roundToInt() + scrollOffset.roundToInt(),
                     )
                 }
             }
@@ -424,7 +445,7 @@ private fun CardHolderNameField(
         isError = state.cardHolderInputField.isError,
         assistiveText = state.cardHolderInputField.errorMessages?.let { AnnotatedString(it) },
         onValueChange = { viewModel.onCardHolderValueChanged(it) },
-        label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_field_card_name)) }
+        label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_field_card_name)) },
     )
 }
 
@@ -436,7 +457,7 @@ private fun EmailField(
     scrollToPosition: Float,
     state: CardDetailsCheckoutState,
     keyboardController: SoftwareKeyboardController?,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     if (state.isEmailInputFieldRequired) {
         val scrollOffset = with(LocalDensity.current) {
@@ -450,13 +471,13 @@ private fun EmailField(
                         coroutineScope.launch {
                             delay(300)
                             scrollState.animateScrollTo(
-                                scrollToPosition.roundToInt() + scrollOffset.roundToInt()
+                                scrollToPosition.roundToInt() + scrollOffset.roundToInt(),
                             )
                         }
                     }
                     viewModel.validateEmailValue(
                         state.emailInputField.value,
-                        it.isFocused
+                        it.isFocused,
                     )
                 },
             isError = state.emailInputField.isError,
@@ -467,7 +488,7 @@ private fun EmailField(
             keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
             value = state.emailInputField.value,
             onValueChange = { viewModel.onEmailValueChanged(it) },
-            label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_field_email)) }
+            label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_field_email)) },
         )
     }
 }
@@ -475,13 +496,13 @@ private fun EmailField(
 @Composable
 private fun BillingCountryField(
     state: CardDetailsCheckoutState,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     if (state.isBillingCountryFieldRequired) {
         CountrySelectorField(
             label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_billing_country)) },
             supportedCountriesViewEntity = state.supportedCountriesList,
-            onCountrySelected = { viewModel.onCountrySelected(it) }
+            onCountrySelected = { viewModel.onCountrySelected(it) },
         )
     }
 }
@@ -494,12 +515,15 @@ private fun PostalCodeField(
     scrollToPosition: Float,
     state: CardDetailsCheckoutState,
     keyboardController: SoftwareKeyboardController?,
-    viewModel: CardDetailsCheckoutViewModel
+    viewModel: CardDetailsCheckoutViewModel,
 ) {
     if (state.isPostalCodeFieldRequired) {
         val scrollOffset = with(LocalDensity.current) {
-            if (state.isEmailInputFieldRequired) SECOND_FIELD_OFF_SET_DP.dp.toPx()
-            else FIRST_FIELD_OFF_SET_DP.dp.toPx()
+            if (state.isEmailInputFieldRequired) {
+                SECOND_FIELD_OFF_SET_DP.dp.toPx()
+            } else {
+                FIRST_FIELD_OFF_SET_DP.dp.toPx()
+            }
         }
         InputFieldWithErrorMessage(
             modifier = Modifier.onFocusChanged {
@@ -507,7 +531,7 @@ private fun PostalCodeField(
                     coroutineScope.launch {
                         delay(300)
                         scrollState.animateScrollTo(
-                            scrollToPosition.roundToInt() + scrollOffset.roundToInt()
+                            scrollToPosition.roundToInt() + scrollOffset.roundToInt(),
                         )
                     }
                 }
@@ -519,18 +543,33 @@ private fun PostalCodeField(
             assistiveText =
             state.postalCodeField.errorMessages?.let { AnnotatedString(it) },
             onValueChange = { viewModel.onPostalCodeValueChanged(it) },
-            label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_billing_postcode)) }
+            label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_billing_postcode)) },
         )
     }
 }
 
 @Composable
-private fun AmountWithPaymentMethodsHeader(state: CardDetailsCheckoutState) {
-    AmountWithPaymentMethodsHeader(
-        amount = state.totalAmount,
-        currencyLogo = state.amountCurrency,
-        allowedPaymentMethodsIcons = state.allowedPaymentMethodsIcons
-    )
+private fun HeaderItem(state: CardDetailsCheckoutState) {
+    when(state.headerType){
+        CardCheckOutHeaderType.AMOUNT_HEADER->{
+            HeaderItem(
+                amount = state.totalAmount,
+                currencyLogo = state.amountCurrency,
+                allowedPaymentMethodsIcons = state.allowedPaymentMethodsIcons,
+            )
+        }
+        CardCheckOutHeaderType.MERCHANT_HEADER->{
+            state.orderId?.let { orderId ->
+                state.merchantName?.let { merchantName ->
+                    MerchantIInfoWithSupportedNetworksHeader(
+                        merchantName = merchantName,
+                        orderId = orderId,
+                        allowedPaymentMethodsIcons = state.allowedPaymentMethodsIcons,
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable
@@ -539,7 +578,7 @@ private fun AppBarItem(onBackClicked: () -> Unit, onCloseClicked: () -> Unit) {
         title = stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_title),
         titleGravity = TitleGravity.LEFT,
         navigationIcon = AppBarIcon.back(DojoTheme.colors.headerButtonTintColor) { onBackClicked() },
-        actionIcon = AppBarIcon.close(DojoTheme.colors.headerButtonTintColor) { onCloseClicked() }
+        actionIcon = AppBarIcon.close(DojoTheme.colors.headerButtonTintColor) { onCloseClicked() },
     )
 }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -3,6 +3,7 @@ package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +20,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
@@ -97,6 +99,7 @@ internal fun CardDetailsCheckoutScreen(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+                Loading(isVisible = state.isLoading)
                 Box(
                     modifier = Modifier
                         .fillMaxHeight()
@@ -202,6 +205,23 @@ internal fun CardDetailsCheckoutScreen(
 }
 
 @Composable
+private fun Loading(isVisible: Boolean) {
+    if (isVisible) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(DojoTheme.colors.primarySurfaceBackgroundColor.copy(alpha = 0.8f))
+                .clickable(false) {},
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator(
+                color = DojoTheme.colors.loadingIndicatorColor,
+            )
+        }
+    }
+}
+
+@Composable
 private fun ScreenFooter(showDojoBrand: Boolean) {
     DojoBrandFooter(
         modifier = Modifier.padding(bottom = 24.dp),
@@ -219,7 +239,7 @@ private fun SaveCardCheckBox(
             itemText = state.checkBoxItem.messageText,
             isChecked = state.checkBoxItem.isChecked,
             onCheckedChange = {
-                viewModel.onSaveCardChecked(it)
+                viewModel.onCheckBoxChecked(it)
             },
         )
     }
@@ -551,15 +571,15 @@ private fun PostalCodeField(
 
 @Composable
 private fun HeaderItem(state: CardDetailsCheckoutState) {
-    when(state.headerType){
-        CardCheckOutHeaderType.AMOUNT_HEADER->{
+    when (state.headerType) {
+        CardCheckOutHeaderType.AMOUNT_HEADER -> {
             HeaderItem(
                 amount = state.totalAmount,
                 currencyLogo = state.amountCurrency,
                 allowedPaymentMethodsIcons = state.allowedPaymentMethodsIcons,
             )
         }
-        CardCheckOutHeaderType.MERCHANT_HEADER->{
+        CardCheckOutHeaderType.MERCHANT_HEADER -> {
             state.orderId?.let { orderId ->
                 state.merchantName?.let { merchantName ->
                     MerchantIInfoWithSupportedNetworksHeader(
@@ -576,7 +596,7 @@ private fun HeaderItem(state: CardDetailsCheckoutState) {
 @Composable
 private fun AppBarItem(onBackClicked: () -> Unit, onCloseClicked: () -> Unit, toolbarTitle: String?) {
     DojoAppBar(
-        title = toolbarTitle?:stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_title),
+        title = toolbarTitle ?: stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_title),
         titleGravity = TitleGravity.LEFT,
         navigationIcon = AppBarIcon.back(DojoTheme.colors.headerButtonTintColor) { onBackClicked() },
         actionIcon = AppBarIcon.close(DojoTheme.colors.headerButtonTintColor) { onCloseClicked() },

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -61,7 +61,7 @@ import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooter
 import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooterModes
 import tech.dojo.pay.uisdk.presentation.components.HeaderItem
 import tech.dojo.pay.uisdk.presentation.components.InputFieldWithErrorMessage
-import tech.dojo.pay.uisdk.presentation.components.MerchantIInfoWithSupportedNetworksHeader
+import tech.dojo.pay.uisdk.presentation.components.MerchantInfoWithSupportedNetworksHeader
 import tech.dojo.pay.uisdk.presentation.components.SingleButtonView
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
@@ -582,7 +582,7 @@ private fun HeaderItem(state: CardDetailsCheckoutState) {
         CardCheckOutHeaderType.MERCHANT_HEADER -> {
             state.orderId?.let { orderId ->
                 state.merchantName?.let { merchantName ->
-                    MerchantIInfoWithSupportedNetworksHeader(
+                    MerchantInfoWithSupportedNetworksHeader(
                         merchantName = merchantName,
                         orderId = orderId,
                         allowedPaymentMethodsIcons = state.allowedPaymentMethodsIcons,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -217,6 +217,7 @@ private fun SaveCardCheckBox(
     if (state.checkBoxItem.isVisible) {
         CheckBoxItem(
             itemText = state.checkBoxItem.messageText,
+            isChecked = state.checkBoxItem.isChecked,
             onCheckedChange = {
                 viewModel.onSaveCardChecked(it)
             },

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
@@ -7,20 +7,24 @@ import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetails
 
 internal class CardCheckOutFullCardPaymentPayloadMapper {
 
-    fun getPaymentPayLoad(currentState: CardDetailsCheckoutState): DojoCardPaymentPayLoad.FullCardPaymentPayload =
+    fun getPaymentPayLoad(
+        currentState: CardDetailsCheckoutState,
+        isStartDestination: Boolean,
+    ): DojoCardPaymentPayLoad.FullCardPaymentPayload =
         DojoCardPaymentPayLoad.FullCardPaymentPayload(
             userEmailAddress = if (currentState.isEmailInputFieldRequired) currentState.emailInputField.value else null,
             billingAddress = DojoAddressDetails(
                 countryCode = if (currentState.isBillingCountryFieldRequired) currentState.currentSelectedCountry.countryCode else null,
                 postcode = if (currentState.isPostalCodeFieldRequired) currentState.postalCodeField.value else null,
             ),
-            savePaymentMethod = currentState.checkBoxItem.isChecked,
+            savePaymentMethod = if (!isStartDestination) currentState.checkBoxItem.isChecked else null,
             cardDetails = DojoCardDetails(
                 cardNumber = currentState.cardNumberInputField.value,
                 cardName = currentState.cardHolderInputField.value,
                 expiryMonth = getExpiryMonth(currentState),
                 expiryYear = getExpiryYear(currentState),
                 cv2 = currentState.cvvInputFieldState.value,
+                mitConsentGiven = if (isStartDestination) currentState.checkBoxItem.isChecked else null,
             ),
         )
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
@@ -28,17 +28,19 @@ internal class CardCheckOutFullCardPaymentPayloadMapper {
             ),
         )
 
-    private fun getExpiryMonth(currentState: CardDetailsCheckoutState) =
-        if (currentState.cardExpireDateInputField.value.isNotBlank()) {
+    private fun getExpiryMonth(currentState: CardDetailsCheckoutState): String {
+        return if (currentState.cardExpireDateInputField.value.isNotBlank() && currentState.cardExpireDateInputField.value.length > 2) {
             currentState.cardExpireDateInputField.value.substring(0, 2)
         } else {
             ""
         }
+    }
 
-    private fun getExpiryYear(currentState: CardDetailsCheckoutState) =
-        if (currentState.cardExpireDateInputField.value.isNotBlank() && currentState.cardExpireDateInputField.value.length > 2) {
+    private fun getExpiryYear(currentState: CardDetailsCheckoutState): String {
+        return if (currentState.cardExpireDateInputField.value.isNotBlank() && currentState.cardExpireDateInputField.value.length == 4) {
             currentState.cardExpireDateInputField.value.substring(2, 4)
         } else {
             ""
         }
+    }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
@@ -17,7 +17,7 @@ internal class CardCheckOutFullCardPaymentPayloadMapper {
                 countryCode = if (currentState.isBillingCountryFieldRequired) currentState.currentSelectedCountry.countryCode else null,
                 postcode = if (currentState.isPostalCodeFieldRequired) currentState.postalCodeField.value else null,
             ),
-            savePaymentMethod = if (!isStartDestination) currentState.checkBoxItem.isChecked else null,
+            savePaymentMethod = if (!isStartDestination && currentState.checkBoxItem.isVisible) currentState.checkBoxItem.isChecked else null,
             cardDetails = DojoCardDetails(
                 cardNumber = currentState.cardNumberInputField.value,
                 cardName = currentState.cardHolderInputField.value,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapper.kt
@@ -1,0 +1,40 @@
+package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper
+
+import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
+import tech.dojo.pay.sdk.card.entities.DojoCardDetails
+import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
+
+internal class CardCheckOutFullCardPaymentPayloadMapper {
+
+    fun getPaymentPayLoad(currentState: CardDetailsCheckoutState): DojoCardPaymentPayLoad.FullCardPaymentPayload =
+        DojoCardPaymentPayLoad.FullCardPaymentPayload(
+            userEmailAddress = if (currentState.isEmailInputFieldRequired) currentState.emailInputField.value else null,
+            billingAddress = DojoAddressDetails(
+                countryCode = if (currentState.isBillingCountryFieldRequired) currentState.currentSelectedCountry.countryCode else null,
+                postcode = if (currentState.isPostalCodeFieldRequired) currentState.postalCodeField.value else null,
+            ),
+            savePaymentMethod = currentState.checkBoxItem.isChecked,
+            cardDetails = DojoCardDetails(
+                cardNumber = currentState.cardNumberInputField.value,
+                cardName = currentState.cardHolderInputField.value,
+                expiryMonth = getExpiryMonth(currentState),
+                expiryYear = getExpiryYear(currentState),
+                cv2 = currentState.cvvInputFieldState.value,
+            ),
+        )
+
+    private fun getExpiryMonth(currentState: CardDetailsCheckoutState) =
+        if (currentState.cardExpireDateInputField.value.isNotBlank()) {
+            currentState.cardExpireDateInputField.value.substring(0, 2)
+        } else {
+            ""
+        }
+
+    private fun getExpiryYear(currentState: CardDetailsCheckoutState) =
+        if (currentState.cardExpireDateInputField.value.isNotBlank() && currentState.cardExpireDateInputField.value.length > 2) {
+            currentState.cardExpireDateInputField.value.substring(2, 4)
+        } else {
+            ""
+        }
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
@@ -5,6 +5,10 @@ import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 
 internal data class CardDetailsCheckoutState(
+    @StringRes var errorMessages: Int = R.string.dojo_ui_sdk_card_details_checkout_title,
+    var orderId: String? = null,
+    var merchantName: String? = null,
+    var isLoading: Boolean = false,
     var totalAmount: String = "",
     var amountCurrency: String = "",
     var allowedPaymentMethodsIcons: List<Int> = listOf(),
@@ -23,7 +27,7 @@ internal data class CardDetailsCheckoutState(
     ),
     var isPostalCodeFieldRequired: Boolean = false,
     var postalCodeField: InputFieldState = InputFieldState(value = ""),
-    var saveCardCheckBox: CheckBoxItem = CheckBoxItem(
+    var checkBoxItem: CheckBoxItem = CheckBoxItem(
         isVisible = false,
         isChecked = true,
         messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
@@ -44,7 +44,7 @@ internal data class CheckBoxItem(
     val messageText: String,
     val isChecked: Boolean,
     val isVisible: Boolean,
-){
+) {
     fun updateText(newValue: String) =
         copy(messageText = newValue)
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
@@ -7,6 +7,7 @@ internal data class CardDetailsCheckoutState(
     var orderId: String? = null,
     var merchantName: String? = null,
     var isLoading: Boolean = false,
+    var headerType: CardCheckOutHeaderType = CardCheckOutHeaderType.AMOUNT_HEADER,
     var totalAmount: String = "",
     var amountCurrency: String = "",
     var allowedPaymentMethodsIcons: List<Int> = listOf(),
@@ -58,4 +59,9 @@ internal data class ActionButtonState(
 
     fun updateText(newValue: String) =
         copy(text = newValue)
+}
+
+internal enum class CardCheckOutHeaderType {
+    AMOUNT_HEADER,
+    MERCHANT_HEADER,
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
@@ -1,11 +1,9 @@
 package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state
 
-import androidx.annotation.StringRes
-import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 
 internal data class CardDetailsCheckoutState(
-    @StringRes var errorMessages: Int = R.string.dojo_ui_sdk_card_details_checkout_title,
+    var toolbarTitle: String = "",
     var orderId: String? = null,
     var merchantName: String? = null,
     var isLoading: Boolean = false,
@@ -30,19 +28,19 @@ internal data class CardDetailsCheckoutState(
     var checkBoxItem: CheckBoxItem = CheckBoxItem(
         isVisible = false,
         isChecked = true,
-        messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+        messageText = "",
     ),
     var actionButtonState: ActionButtonState = ActionButtonState(),
 )
 
 internal data class InputFieldState(
     val value: String,
-    @StringRes val errorMessages: Int? = null,
+    val errorMessages: String? = null,
     val isError: Boolean = false,
 )
 
 internal data class CheckBoxItem(
-    @StringRes val messageText: Int,
+    val messageText: String,
     val isChecked: Boolean,
     val isVisible: Boolean,
 )
@@ -51,4 +49,13 @@ internal data class ActionButtonState(
     val isLoading: Boolean = false,
     val isEnabled: Boolean = false,
     val text: String = "",
-)
+) {
+    fun updateIsEnabled(newValue: Boolean) =
+        copy(isEnabled = newValue)
+
+    fun updateIsLoading(newValue: Boolean) =
+        copy(isLoading = newValue)
+
+    fun updateText(newValue: String) =
+        copy(text = newValue)
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
@@ -1,36 +1,50 @@
 package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state
 
 import androidx.annotation.StringRes
+import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 
 internal data class CardDetailsCheckoutState(
-    val totalAmount: String,
-    val amountCurrency: String,
-    val allowedPaymentMethodsIcons: List<Int>,
-    val cardHolderInputField: InputFieldState,
-    val emailInputField: InputFieldState,
-    val isEmailInputFieldRequired: Boolean,
-    val cardNumberInputField: InputFieldState,
-    val cardExpireDateInputField: InputFieldState,
-    val cvvInputFieldState: InputFieldState,
-    val isBillingCountryFieldRequired: Boolean,
-    val supportedCountriesList: List<SupportedCountriesViewEntity>,
-    val currentSelectedCountry: SupportedCountriesViewEntity,
-    val isPostalCodeFieldRequired: Boolean,
-    val postalCodeField: InputFieldState,
-    val saveCardCheckBox: CheckBoxItem,
-    val isLoading: Boolean,
-    val isEnabled: Boolean
+    var totalAmount: String = "",
+    var amountCurrency: String = "",
+    var allowedPaymentMethodsIcons: List<Int> = listOf(),
+    var cardHolderInputField: InputFieldState = InputFieldState(value = ""),
+    var emailInputField: InputFieldState = InputFieldState(value = ""),
+    var isEmailInputFieldRequired: Boolean = false,
+    var cardNumberInputField: InputFieldState = InputFieldState(value = ""),
+    var cardExpireDateInputField: InputFieldState = InputFieldState(value = ""),
+    var cvvInputFieldState: InputFieldState = InputFieldState(value = ""),
+    var isBillingCountryFieldRequired: Boolean = false,
+    var supportedCountriesList: List<SupportedCountriesViewEntity> = listOf(),
+    var currentSelectedCountry: SupportedCountriesViewEntity = SupportedCountriesViewEntity(
+        "",
+        "",
+        false,
+    ),
+    var isPostalCodeFieldRequired: Boolean = false,
+    var postalCodeField: InputFieldState = InputFieldState(value = ""),
+    var saveCardCheckBox: CheckBoxItem = CheckBoxItem(
+        isVisible = false,
+        isChecked = true,
+        messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+    ),
+    var actionButtonState: ActionButtonState = ActionButtonState(),
 )
 
 internal data class InputFieldState(
     val value: String,
     @StringRes val errorMessages: Int? = null,
-    val isError: Boolean = false
+    val isError: Boolean = false,
 )
 
 internal data class CheckBoxItem(
     @StringRes val messageText: Int,
     val isChecked: Boolean,
-    val isVisible: Boolean
+    val isVisible: Boolean,
+)
+
+internal data class ActionButtonState(
+    val isLoading: Boolean = false,
+    val isEnabled: Boolean = false,
+    val text: String = "",
 )

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/state/CardDetailsCheckoutState.kt
@@ -3,11 +3,11 @@ package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 
 internal data class CardDetailsCheckoutState(
+    var isLoading: Boolean = false,
     var toolbarTitle: String = "",
+    var headerType: CardCheckOutHeaderType = CardCheckOutHeaderType.AMOUNT_HEADER,
     var orderId: String? = null,
     var merchantName: String? = null,
-    var isLoading: Boolean = false,
-    var headerType: CardCheckOutHeaderType = CardCheckOutHeaderType.AMOUNT_HEADER,
     var totalAmount: String = "",
     var amountCurrency: String = "",
     var allowedPaymentMethodsIcons: List<Int> = listOf(),
@@ -28,7 +28,7 @@ internal data class CardDetailsCheckoutState(
     var postalCodeField: InputFieldState = InputFieldState(value = ""),
     var checkBoxItem: CheckBoxItem = CheckBoxItem(
         isVisible = false,
-        isChecked = true,
+        isChecked = false,
         messageText = "",
     ),
     var actionButtonState: ActionButtonState = ActionButtonState(),
@@ -44,7 +44,16 @@ internal data class CheckBoxItem(
     val messageText: String,
     val isChecked: Boolean,
     val isVisible: Boolean,
-)
+){
+    fun updateText(newValue: String) =
+        copy(messageText = newValue)
+
+    fun updateIsChecked(newValue: Boolean) =
+        copy(isChecked = newValue)
+
+    fun updateIsVisible(newValue: Boolean) =
+        copy(isVisible = newValue)
+}
 
 internal data class ActionButtonState(
     val isLoading: Boolean = false,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/validator/CardCheckoutScreenValidator.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/validator/CardCheckoutScreenValidator.kt
@@ -9,7 +9,7 @@ internal class CardCheckoutScreenValidator {
 
     fun isEmailFieldValidWithInputFieldVisibility(
         emailValue: String,
-        isInputFieldVisible: Boolean
+        isInputFieldVisible: Boolean,
     ): Boolean {
         return if (isInputFieldVisible) {
             isEmailValid(emailValue)
@@ -20,7 +20,7 @@ internal class CardCheckoutScreenValidator {
 
     fun isPostalCodeFieldWithInputFieldVisibility(
         postalCodeValue: String,
-        isInputFieldVisible: Boolean
+        isInputFieldVisible: Boolean,
     ): Boolean {
         return if (isInputFieldVisible) {
             postalCodeValue.isNotBlank()
@@ -61,4 +61,8 @@ internal class CardCheckoutScreenValidator {
     }
 
     fun isCvvValid(cvvValue: String): Boolean = cvvValue.length > 2
+
+    fun isCheckBoxValid(isStartDestination: Boolean, isCheckBoxChecked: Boolean): Boolean {
+        return if (isStartDestination) isCheckBoxChecked else true
+    }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -281,7 +281,7 @@ internal class CardDetailsCheckoutViewModel(
             currentState = currentState.copy(
                 totalAmount = paymentIntentResult.result.amount.valueString,
                 amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
-                saveCardCheckBox = currentState.saveCardCheckBox.copy(
+                checkBoxItem = currentState.checkBoxItem.copy(
                     isVisible = !paymentIntentResult.result.customerId.isNullOrBlank(),
                     isChecked = !paymentIntentResult.result.customerId.isNullOrBlank(),
                 ),
@@ -328,8 +328,8 @@ internal class CardDetailsCheckoutViewModel(
     }
 
     fun onSaveCardChecked(isChecked: Boolean) {
-        val newCheckBoxItem = currentState.saveCardCheckBox.copy(isChecked = isChecked)
-        currentState = currentState.copy(saveCardCheckBox = newCheckBoxItem)
+        val newCheckBoxItem = currentState.checkBoxItem.copy(isChecked = isChecked)
+        currentState = currentState.copy(checkBoxItem = newCheckBoxItem)
     }
 
     fun onPayWithCardClicked() {
@@ -354,7 +354,7 @@ internal class CardDetailsCheckoutViewModel(
                 countryCode = if (currentState.isBillingCountryFieldRequired) currentState.currentSelectedCountry.countryCode else null,
                 postcode = if (currentState.isPostalCodeFieldRequired) currentState.postalCodeField.value else null,
             ),
-            savePaymentMethod = currentState.saveCardCheckBox.isChecked,
+            savePaymentMethod = currentState.checkBoxItem.isChecked,
             cardDetails = DojoCardDetails(
                 cardNumber = currentState.cardNumberInputField.value,
                 cardName = currentState.cardHolderInputField.value,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -18,8 +18,8 @@ import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.SupportedCountriesViewEntityMapper
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.ActionButtonState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
-import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CheckBoxItem
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.InputFieldState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.validator.CardCheckoutScreenValidator
 import java.util.Currency
@@ -40,33 +40,13 @@ internal class CardDetailsCheckoutViewModel(
     private val mutableState = MutableLiveData<CardDetailsCheckoutState>()
     val state: LiveData<CardDetailsCheckoutState>
         get() = mutableState
+
     fun updateCardPaymentHandler(newDojoCardPaymentHandler: DojoCardPaymentHandler) {
         dojoCardPaymentHandler = newDojoCardPaymentHandler
     }
+
     init {
-        currentState = CardDetailsCheckoutState(
-            totalAmount = "",
-            amountCurrency = "",
-            allowedPaymentMethodsIcons = emptyList(),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            isBillingCountryFieldRequired = false,
-            supportedCountriesList = emptyList(),
-            currentSelectedCountry = SupportedCountriesViewEntity("", "", false),
-            isPostalCodeFieldRequired = false,
-            postalCodeField = InputFieldState(value = ""),
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            saveCardCheckBox = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
-            ),
-            isLoading = false,
-            isEnabled = false,
-        )
+        currentState = CardDetailsCheckoutState()
         pushStateToUi(currentState)
         viewModelScope.launch { observePaymentIntent() }
         viewModelScope.launch { observePaymentStatus() }
@@ -80,12 +60,12 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_card_holder,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         } else {
             currentState.copy(
                 cardHolderInputField = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(cardHolderValue = newValue),
+                actionButtonState = ActionButtonState(isEnabled = isPayButtonEnabled(cardHolderValue = newValue)),
             )
         }
 
@@ -100,12 +80,12 @@ internal class CardDetailsCheckoutViewModel(
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_billing_postcode,
                     isError = true,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         } else {
             currentState.copy(
                 postalCodeField = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(postalCodeValue = newValue),
+                actionButtonState = ActionButtonState(isEnabled = isPayButtonEnabled(postalCodeValue = newValue)),
             )
         }
         pushStateToUi(currentState)
@@ -114,7 +94,7 @@ internal class CardDetailsCheckoutViewModel(
     fun onCardNumberValueChanged(newValue: String) {
         currentState = currentState.copy(
             cardNumberInputField = InputFieldState(value = newValue),
-            isEnabled = isPayButtonEnabled(cardNumberValue = newValue),
+            actionButtonState = ActionButtonState(isEnabled = isPayButtonEnabled(cardNumberValue = newValue)),
         )
         pushStateToUi(currentState)
     }
@@ -127,7 +107,7 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_card_number,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         } else if (!cardCheckoutScreenValidator.isCardNumberValid(cardNumberValue)) {
             currentState = currentState.copy(
@@ -136,7 +116,7 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_card_number,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         }
         pushStateToUi(currentState)
@@ -150,12 +130,12 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_cvv,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         } else {
             currentState.copy(
                 cvvInputFieldState = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(cvvValue = newValue),
+                actionButtonState = ActionButtonState(isEnabled = isPayButtonEnabled(cvvValue = newValue)),
             )
         }
 
@@ -173,7 +153,7 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_cvv,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         }
         pushStateToUi(currentState)
@@ -187,12 +167,12 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_expiry,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         } else {
             currentState.copy(
                 cardExpireDateInputField = InputFieldState(newValue),
-                isEnabled = isPayButtonEnabled(cardExpireDate = newValue),
+                actionButtonState = ActionButtonState(isEnabled = isPayButtonEnabled(cardExpireDate = newValue)),
             )
         }
         pushStateToUi(currentState)
@@ -209,7 +189,7 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_expiry,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         }
         pushStateToUi(currentState)
@@ -223,12 +203,12 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_empty_email,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         } else {
             currentState.copy(
                 emailInputField = InputFieldState(value = newValue),
-                isEnabled = isPayButtonEnabled(emailValue = newValue),
+                actionButtonState = ActionButtonState(isEnabled = isPayButtonEnabled(emailValue = newValue)),
             )
         }
         pushStateToUi(currentState)
@@ -245,7 +225,7 @@ internal class CardDetailsCheckoutViewModel(
                     isError = true,
                     errorMessages = R.string.dojo_ui_sdk_card_details_checkout_error_invalid_email,
                 ),
-                isEnabled = false,
+                actionButtonState = ActionButtonState(isEnabled = false),
             )
         }
         pushStateToUi(currentState)
@@ -289,7 +269,8 @@ internal class CardDetailsCheckoutViewModel(
 
     private fun handlePaymentIntent(paymentIntentResult: PaymentIntentResult) {
         if (paymentIntentResult is PaymentIntentResult.Success) {
-            val countryList = getSupportedCountriesList(paymentIntentResult.result.collectionBillingAddressRequired)
+            val countryList =
+                getSupportedCountriesList(paymentIntentResult.result.collectionBillingAddressRequired)
             val currentSelectedCountry = if (countryList.isNotEmpty()) {
                 getSupportedCountriesList(paymentIntentResult.result.collectionBillingAddressRequired)[0]
             } else {
@@ -300,7 +281,10 @@ internal class CardDetailsCheckoutViewModel(
             currentState = currentState.copy(
                 totalAmount = paymentIntentResult.result.amount.valueString,
                 amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
-                saveCardCheckBox = currentState.saveCardCheckBox.copy(isVisible = !paymentIntentResult.result.customerId.isNullOrBlank(), isChecked = !paymentIntentResult.result.customerId.isNullOrBlank()),
+                saveCardCheckBox = currentState.saveCardCheckBox.copy(
+                    isVisible = !paymentIntentResult.result.customerId.isNullOrBlank(),
+                    isChecked = !paymentIntentResult.result.customerId.isNullOrBlank(),
+                ),
                 allowedPaymentMethodsIcons = allowedPaymentMethodsViewEntityMapper.apply(
                     paymentIntentResult.result.supportedCardsSchemes,
                 ),
@@ -325,16 +309,20 @@ internal class CardDetailsCheckoutViewModel(
     }
 
     private fun applyIsPostalCodeFieldRequiredLogic(
-        SupportedCountryItem: SupportedCountriesViewEntity,
+        supportedCountryItem: SupportedCountriesViewEntity,
         collectionBillingAddressRequired: Boolean,
     ): Boolean {
-        return SupportedCountryItem.isPostalCodeEnabled && collectionBillingAddressRequired
+        return supportedCountryItem.isPostalCodeEnabled && collectionBillingAddressRequired
     }
 
     private suspend fun observePaymentStatus() {
         observePaymentStatus.observePaymentStates().collect {
             if (!it) {
-                pushStateToUi(currentState.copy(isLoading = false))
+                pushStateToUi(
+                    currentState.copy(
+                        actionButtonState = ActionButtonState(isLoading = false),
+                    ),
+                )
             }
         }
     }
@@ -347,7 +335,11 @@ internal class CardDetailsCheckoutViewModel(
     fun onPayWithCardClicked() {
         viewModelScope.launch { observePaymentIntent() }
         updatePaymentStateUseCase.updatePaymentSate(isActive = true)
-        pushStateToUi(currentState.copy(isLoading = true))
+        pushStateToUi(
+            currentState.copy(
+                actionButtonState = ActionButtonState(isLoading = true),
+            ),
+        )
         dojoCardPaymentHandler.executeCardPayment(paymentToken, getPaymentPayLoad())
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -54,7 +54,7 @@ internal class CardDetailsCheckoutViewModel(
             isLoading = isStartDestination,
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
+                isChecked = !isStartDestination,
                 messageText = "",
             ),
         )
@@ -63,7 +63,7 @@ internal class CardDetailsCheckoutViewModel(
         viewModelScope.launch { observePaymentStatus() }
     }
 
-    private fun getToolBarTitle() = if (isStartDestination) {
+    private fun getToolBarTitle() = if (!isStartDestination) {
         stringProvider.getString(R.string.dojo_ui_sdk_save_card_title)
     } else {
         stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)
@@ -329,11 +329,10 @@ internal class CardDetailsCheckoutViewModel(
                 merchantName = paymentIntentResult.result.merchantName,
                 totalAmount = paymentIntentResult.result.amount.valueString,
                 amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
-                checkBoxItem = currentState.checkBoxItem.copy(
-                    isVisible = !paymentIntentResult.result.customerId.isNullOrBlank(),
-                    isChecked = !paymentIntentResult.result.customerId.isNullOrBlank() && !isStartDestination,
-                    messageText = getCheckBoxMessage(paymentIntentResult),
-                ),
+                checkBoxItem = currentState
+                    .checkBoxItem
+                    .updateIsVisible(!paymentIntentResult.result.customerId.isNullOrBlank())
+                    .updateText(getCheckBoxMessage(paymentIntentResult)),
                 allowedPaymentMethodsIcons = allowedPaymentMethodsViewEntityMapper.apply(
                     paymentIntentResult.result.supportedCardsSchemes,
                 ),
@@ -361,7 +360,7 @@ internal class CardDetailsCheckoutViewModel(
                 stringProvider.getString(R.string.dojo_ui_sdk_save_card_confirmation_message),
             )
         } else {
-            stringProvider.getString(R.string.dojo_ui_sdk_save_card_confirmation_message)
+            stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)
         }
 
     private fun getActionButtonTitle(paymentIntentResult: PaymentIntentResult.Success) =

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -106,7 +106,11 @@ internal class CardDetailsCheckoutViewModel(
         } else {
             currentState.copy(
                 postalCodeField = InputFieldState(value = newValue),
-                actionButtonState = currentState.actionButtonState.updateIsEnabled(newValue = isPayButtonEnabled(postalCodeValue = newValue)),
+                actionButtonState = currentState.actionButtonState.updateIsEnabled(
+                    newValue = isPayButtonEnabled(
+                        postalCodeValue = newValue,
+                    ),
+                ),
             )
         }
         pushStateToUi(currentState)
@@ -115,7 +119,11 @@ internal class CardDetailsCheckoutViewModel(
     fun onCardNumberValueChanged(newValue: String) {
         currentState = currentState.copy(
             cardNumberInputField = InputFieldState(value = newValue),
-            actionButtonState = currentState.actionButtonState.updateIsEnabled(newValue = isPayButtonEnabled(cardNumberValue = newValue)),
+            actionButtonState = currentState.actionButtonState.updateIsEnabled(
+                newValue = isPayButtonEnabled(
+                    cardNumberValue = newValue,
+                ),
+            ),
         )
         pushStateToUi(currentState)
     }
@@ -156,7 +164,11 @@ internal class CardDetailsCheckoutViewModel(
         } else {
             currentState.copy(
                 cvvInputFieldState = InputFieldState(value = newValue),
-                actionButtonState = currentState.actionButtonState.updateIsEnabled(newValue = isPayButtonEnabled(cvvValue = newValue)),
+                actionButtonState = currentState.actionButtonState.updateIsEnabled(
+                    newValue = isPayButtonEnabled(
+                        cvvValue = newValue,
+                    ),
+                ),
             )
         }
 
@@ -193,7 +205,11 @@ internal class CardDetailsCheckoutViewModel(
         } else {
             currentState.copy(
                 cardExpireDateInputField = InputFieldState(newValue),
-                actionButtonState = currentState.actionButtonState.updateIsEnabled(newValue = isPayButtonEnabled(cardExpireDate = newValue)),
+                actionButtonState = currentState.actionButtonState.updateIsEnabled(
+                    newValue = isPayButtonEnabled(
+                        cardExpireDate = newValue,
+                    ),
+                ),
             )
         }
         pushStateToUi(currentState)
@@ -229,7 +245,11 @@ internal class CardDetailsCheckoutViewModel(
         } else {
             currentState.copy(
                 emailInputField = InputFieldState(value = newValue),
-                actionButtonState = currentState.actionButtonState.updateIsEnabled(newValue = isPayButtonEnabled(emailValue = newValue)),
+                actionButtonState = currentState.actionButtonState.updateIsEnabled(
+                    newValue = isPayButtonEnabled(
+                        emailValue = newValue,
+                    ),
+                ),
             )
         }
         pushStateToUi(currentState)
@@ -300,14 +320,19 @@ internal class CardDetailsCheckoutViewModel(
             paymentToken = paymentIntentResult.result.paymentToken
             currentState = currentState.copy(
                 isLoading = false,
-                headerType = if (isStartDestination) { CardCheckOutHeaderType.MERCHANT_HEADER } else { CardCheckOutHeaderType.AMOUNT_HEADER },
+                headerType = if (isStartDestination) {
+                    CardCheckOutHeaderType.MERCHANT_HEADER
+                } else {
+                    CardCheckOutHeaderType.AMOUNT_HEADER
+                },
                 orderId = paymentIntentResult.result.orderId,
                 merchantName = paymentIntentResult.result.merchantName,
                 totalAmount = paymentIntentResult.result.amount.valueString,
                 amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
                 checkBoxItem = currentState.checkBoxItem.copy(
                     isVisible = !paymentIntentResult.result.customerId.isNullOrBlank(),
-                    isChecked = !paymentIntentResult.result.customerId.isNullOrBlank(),
+                    isChecked = !paymentIntentResult.result.customerId.isNullOrBlank() && !isStartDestination,
+                    messageText = getCheckBoxMessage(paymentIntentResult),
                 ),
                 allowedPaymentMethodsIcons = allowedPaymentMethodsViewEntityMapper.apply(
                     paymentIntentResult.result.supportedCardsSchemes,
@@ -317,11 +342,27 @@ internal class CardDetailsCheckoutViewModel(
                 supportedCountriesList = countryList,
                 currentSelectedCountry = currentSelectedCountry,
                 isPostalCodeFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
-                actionButtonState = currentState.actionButtonState.updateText(newValue = getActionButtonTitle(paymentIntentResult)),
+                actionButtonState = currentState.actionButtonState.updateText(
+                    newValue = getActionButtonTitle(
+                        paymentIntentResult,
+                    ),
+                ),
             )
             pushStateToUi(currentState)
         }
     }
+
+    private fun getCheckBoxMessage(paymentIntentResult: PaymentIntentResult.Success) =
+        if (isStartDestination) {
+            String.format(
+                Locale.getDefault(),
+                "%s %s",
+                paymentIntentResult.result.merchantName,
+                stringProvider.getString(R.string.dojo_ui_sdk_save_card_confirmation_message),
+            )
+        } else {
+            stringProvider.getString(R.string.dojo_ui_sdk_save_card_confirmation_message)
+        }
 
     private fun getActionButtonTitle(paymentIntentResult: PaymentIntentResult.Success) =
         if (isStartDestination) {
@@ -380,7 +421,7 @@ internal class CardDetailsCheckoutViewModel(
         )
         dojoCardPaymentHandler.executeCardPayment(
             paymentToken,
-            fullCardPaymentPayloadMapper.getPaymentPayLoad(currentState),
+            fullCardPaymentPayloadMapper.getPaymentPayLoad(currentState, isStartDestination),
         )
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -359,7 +359,7 @@ internal class CardDetailsCheckoutViewModel(
         CardCheckOutHeaderType.AMOUNT_HEADER
     }
 
-    private fun getToolBarTitle() = if (!isStartDestination) {
+    private fun getToolBarTitle() = if (isStartDestination) {
         stringProvider.getString(R.string.dojo_ui_sdk_save_card_title)
     } else {
         stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -290,6 +290,7 @@ internal class CardDetailsCheckoutViewModel(
         cardExpireDate: String = currentState.cardExpireDateInputField.value,
         emailValue: String = currentState.emailInputField.value,
         postalCodeValue: String = currentState.postalCodeField.value,
+        isCheckBoxChecked: Boolean = currentState.checkBoxItem.isChecked,
     ) =
         cardHolderValue.isNotBlank() &&
             cardCheckoutScreenValidator.isCardNumberValid(cardNumberValue) &&
@@ -302,7 +303,8 @@ internal class CardDetailsCheckoutViewModel(
             cardCheckoutScreenValidator.isPostalCodeFieldWithInputFieldVisibility(
                 postalCodeValue,
                 currentState.isPostalCodeFieldRequired,
-            )
+            ) &&
+            cardCheckoutScreenValidator.isCheckBoxValid(isStartDestination, isCheckBoxChecked)
 
     private suspend fun observePaymentIntent() {
         observePaymentIntent.observePaymentIntent().collect { it?.let { handlePaymentIntent(it) } }
@@ -405,9 +407,15 @@ internal class CardDetailsCheckoutViewModel(
         }
     }
 
-    fun onSaveCardChecked(isChecked: Boolean) {
+    fun onCheckBoxChecked(isChecked: Boolean) {
         val newCheckBoxItem = currentState.checkBoxItem.copy(isChecked = isChecked)
-        currentState = currentState.copy(checkBoxItem = newCheckBoxItem)
+        currentState = currentState.copy(
+            checkBoxItem = newCheckBoxItem,
+            actionButtonState = currentState.actionButtonState.updateIsEnabled(
+                isPayButtonEnabled(isCheckBoxChecked = isChecked),
+            ),
+        )
+        pushStateToUi(currentState)
     }
 
     fun onPayWithCardClicked() {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -63,12 +63,6 @@ internal class CardDetailsCheckoutViewModel(
         viewModelScope.launch { observePaymentStatus() }
     }
 
-    private fun getToolBarTitle() = if (!isStartDestination) {
-        stringProvider.getString(R.string.dojo_ui_sdk_save_card_title)
-    } else {
-        stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)
-    }
-
     fun onCardHolderValueChanged(newValue: String) {
         currentState = if (newValue.isBlank()) {
             currentState.copy(
@@ -320,37 +314,55 @@ internal class CardDetailsCheckoutViewModel(
                 SupportedCountriesViewEntity("", "", true)
             }
             paymentToken = paymentIntentResult.result.paymentToken
-            currentState = currentState.copy(
-                isLoading = false,
-                headerType = if (isStartDestination) {
-                    CardCheckOutHeaderType.MERCHANT_HEADER
-                } else {
-                    CardCheckOutHeaderType.AMOUNT_HEADER
-                },
-                orderId = paymentIntentResult.result.orderId,
-                merchantName = paymentIntentResult.result.merchantName,
-                totalAmount = paymentIntentResult.result.amount.valueString,
-                amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
-                checkBoxItem = currentState
-                    .checkBoxItem
-                    .updateIsVisible(!paymentIntentResult.result.customerId.isNullOrBlank())
-                    .updateText(getCheckBoxMessage(paymentIntentResult)),
-                allowedPaymentMethodsIcons = allowedPaymentMethodsViewEntityMapper.apply(
-                    paymentIntentResult.result.supportedCardsSchemes,
-                ),
-                isEmailInputFieldRequired = paymentIntentResult.result.collectionEmailRequired,
-                isBillingCountryFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
-                supportedCountriesList = countryList,
-                currentSelectedCountry = currentSelectedCountry,
-                isPostalCodeFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
-                actionButtonState = currentState.actionButtonState.updateText(
-                    newValue = getActionButtonTitle(
-                        paymentIntentResult,
-                    ),
-                ),
+            currentState = updateCurrentStateWithPaymentIntent(
+                paymentIntentResult,
+                countryList,
+                currentSelectedCountry,
             )
             pushStateToUi(currentState)
         }
+    }
+
+    private fun updateCurrentStateWithPaymentIntent(
+        paymentIntentResult: PaymentIntentResult.Success,
+        countryList: List<SupportedCountriesViewEntity>,
+        currentSelectedCountry: SupportedCountriesViewEntity,
+    ) = currentState.copy(
+        isLoading = false,
+        headerType = getHeaderType(),
+        orderId = paymentIntentResult.result.orderId,
+        merchantName = paymentIntentResult.result.merchantName,
+        totalAmount = paymentIntentResult.result.amount.valueString,
+        amountCurrency = Currency.getInstance(paymentIntentResult.result.amount.currencyCode).symbol,
+        checkBoxItem = currentState
+            .checkBoxItem
+            .updateIsVisible(!paymentIntentResult.result.customerId.isNullOrBlank())
+            .updateText(getCheckBoxMessage(paymentIntentResult)),
+        allowedPaymentMethodsIcons = allowedPaymentMethodsViewEntityMapper.apply(
+            paymentIntentResult.result.supportedCardsSchemes,
+        ),
+        isEmailInputFieldRequired = paymentIntentResult.result.collectionEmailRequired,
+        isBillingCountryFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
+        supportedCountriesList = countryList,
+        currentSelectedCountry = currentSelectedCountry,
+        isPostalCodeFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
+        actionButtonState = currentState.actionButtonState.updateText(
+            newValue = getActionButtonTitle(
+                paymentIntentResult,
+            ),
+        ),
+    )
+
+    private fun getHeaderType() = if (isStartDestination) {
+        CardCheckOutHeaderType.MERCHANT_HEADER
+    } else {
+        CardCheckOutHeaderType.AMOUNT_HEADER
+    }
+
+    private fun getToolBarTitle() = if (!isStartDestination) {
+        stringProvider.getString(R.string.dojo_ui_sdk_save_card_title)
+    } else {
+        stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)
     }
 
     private fun getCheckBoxMessage(paymentIntentResult: PaymentIntentResult.Success) =

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
@@ -12,6 +12,7 @@ import tech.dojo.pay.uisdk.domain.ObservePaymentStatus
 import tech.dojo.pay.uisdk.domain.UpdatePaymentStateUseCase
 import tech.dojo.pay.uisdk.presentation.PaymentFlowViewModelFactory
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.CardCheckOutFullCardPaymentPayloadMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.SupportedCountriesViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.validator.CardCheckoutScreenValidator
 
@@ -39,6 +40,7 @@ class CardDetailsCheckoutViewModelFactory(
         val allowedPaymentMethodsViewEntityMapper =
             AllowedPaymentMethodsViewEntityMapper(isDarkModeEnabled)
         val cardCheckoutScreenValidator = CardCheckoutScreenValidator()
+        val fullCardPaymentPayloadMapper = CardCheckOutFullCardPaymentPayloadMapper()
 
         return CardDetailsCheckoutViewModel(
             observePaymentIntent,
@@ -49,6 +51,7 @@ class CardDetailsCheckoutViewModelFactory(
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            fullCardPaymentPayloadMapper,
         ) as T
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
@@ -21,6 +21,7 @@ class CardDetailsCheckoutViewModelFactory(
     private val dojoCardPaymentHandler: DojoCardPaymentHandler,
     private val isDarkModeEnabled: Boolean,
     private val context: Context,
+    private val isStartDestination: Boolean,
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -55,6 +56,7 @@ class CardDetailsCheckoutViewModelFactory(
             cardCheckoutScreenValidator,
             fullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         ) as T
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
+import tech.dojo.pay.uisdk.core.StringProvider
 import tech.dojo.pay.uisdk.data.supportedcountries.SupportedCountriesDataSource
 import tech.dojo.pay.uisdk.data.supportedcountries.SupportedCountriesRepository
 import tech.dojo.pay.uisdk.domain.GetSupportedCountriesUseCase
@@ -41,6 +42,7 @@ class CardDetailsCheckoutViewModelFactory(
             AllowedPaymentMethodsViewEntityMapper(isDarkModeEnabled)
         val cardCheckoutScreenValidator = CardCheckoutScreenValidator()
         val fullCardPaymentPayloadMapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val stringProvider = StringProvider(context)
 
         return CardDetailsCheckoutViewModel(
             observePaymentIntent,
@@ -52,6 +54,7 @@ class CardDetailsCheckoutViewModelFactory(
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             fullCardPaymentPayloadMapper,
+            stringProvider,
         ) as T
     }
 }

--- a/uisdk/src/main/res/values/strings.xml
+++ b/uisdk/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name = "dojo_ui_sdk_card_details_checkout_button_pay">Pay</string>
     <string name = "dojo_ui_sdk_card_details_checkout_button_processing">Processing....</string>
     <string name = "dojo_ui_sdk_card_details_checkout_field_email">Email</string>
-    <string name = "dojo_ui_sdk_card_details_checkout_billing_country">Billing Country</string>
+    <string name = "dojo_ui_sdk_card_details_checkout_billing_country">Country</string>
     <string name = "dojo_ui_sdk_card_details_checkout_billing_postcode">Postcode</string>
     <string name = "dojo_ui_sdk_card_details_checkout_billing_zipcode">Zipcode</string>
     <string name = "dojo_ui_sdk_card_details_checkout_expiry_date">Expiry date</string>
@@ -51,7 +51,7 @@
     <string name = "dojo_ui_sdk_mange_payments_dialog_cancel_text">Cancel</string>
     <string name = "dojo_ui_sdk_keyboard_additional_button_next">Next</string>
     <string name = "dojo_ui_sdk_keyboard_additional_button_previous">Previous</string>
-    <string name = "dojo_ui_sdk_dojo_ui_sdk_card_details_checkout_optional">(optional)</string>
+    <string name = "dojo_ui_sdk_dojo_ui_sdk_card_details_checkout_optional">optional</string>
     <string name = "dojo_ui_sdk_card_details_checkout_field_shipping_name">Name</string>
     <string name = "dojo_ui_sdk_card_details_checkout_field_shipping_line_1">Address line 1</string>
     <string name = "dojo_ui_sdk_card_details_checkout_field_shipping_line_2">Address line 2</string>
@@ -70,5 +70,7 @@
     <string name = "dojo_ui_sdk_card_details_checkout_error_empty_shipping_city">Please fill in your city</string>
     <string name = "dojo_ui_sdk_card_details_checkout_error_empty_shipping_postal">Please fill in your postal code</string>
     <string name = "dojo_ui_sdk_order_info">Order: &#160;</string>
-
+    <string name = "dojo_ui_sdk_save_card_confirmation_message">requires your payment card information to secure this booking and you may be charged for no-shows or cancellations in accordance with their booking policy.</string>
+    <string name = "dojo_ui_sdk_save_card_title">Save card details</string>
+    <string name = "dojo_ui_sdk_save_card_button_text">Save card</string>
 </resources>

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentIntentUseCaseTest.kt
@@ -52,7 +52,7 @@ class FetchPaymentIntentUseCaseTest {
         val paymentId = "paymentId"
 
         // when
-        useCase.fetchPaymentIntentWithPaymentType(DojoPaymentType.CARD_ON_FILE, paymentId)
+        useCase.fetchPaymentIntentWithPaymentType(DojoPaymentType.SETUP_INTENT, paymentId)
 
         // then
         verify {

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/FetchPaymentMethodsUseCaseTest.kt
@@ -26,7 +26,7 @@ class FetchPaymentMethodsUseCaseTest {
 
         // when
         useCase.fetchPaymentMethodsWithPaymentType(
-            DojoPaymentType.CARD_ON_FILE,
+            DojoPaymentType.SETUP_INTENT,
             customerId,
             customerSecret,
         )

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
@@ -1,6 +1,7 @@
 package tech.dojo.pay.uisdk.domain
 
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
@@ -8,6 +9,12 @@ import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
 
 class IsSDKInitializedCorrectlyUseCaseTest {
+    private lateinit var useCase: IsSDKInitializedCorrectlyUseCase
+
+    @Before
+    fun setUp() {
+        useCase = IsSDKInitializedCorrectlyUseCase()
+    }
 
     @Test
     fun `when calling isSDKInitiatedCorrectly with Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
@@ -15,7 +22,6 @@ class IsSDKInitializedCorrectlyUseCaseTest {
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.VIRTUAL_TERMINAL
         given(paymentIntent.isVirtualTerminalPayment).willReturn(true)
-        val useCase = IsSDKInitializedCorrectlyUseCase()
 
         // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
@@ -30,7 +36,6 @@ class IsSDKInitializedCorrectlyUseCaseTest {
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
         given(paymentIntent.isSetUpIntentPayment).willReturn(true)
-        val useCase = IsSDKInitializedCorrectlyUseCase()
 
         // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
@@ -44,7 +49,6 @@ class IsSDKInitializedCorrectlyUseCaseTest {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.PAYMENT_CARD
-        val useCase = IsSDKInitializedCorrectlyUseCase()
 
         // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
@@ -58,7 +62,6 @@ class IsSDKInitializedCorrectlyUseCaseTest {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
-        val useCase = IsSDKInitializedCorrectlyUseCase()
 
         // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
@@ -1,0 +1,69 @@
+package tech.dojo.pay.uisdk.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
+import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
+import tech.dojo.pay.uisdk.entities.DojoPaymentType
+
+class IsSDKInitializedCorrectlyUseCaseTest {
+
+    @Test
+    fun `given Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly should return true`() {
+        // Arrange
+        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+        val paymentType = DojoPaymentType.VIRTUAL_TERMINAL
+        whenever(paymentIntent.isVirtualTerminalPayment).thenReturn(true)
+        val useCase = IsSDKInitializedCorrectlyUseCase()
+
+        // Act
+        val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
+
+        // Assert
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `given Setup Intent PaymentIntent, isSDKInitiatedCorrectly should return true`() {
+        // Arrange
+        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+        val paymentType = DojoPaymentType.SETUP_INTENT
+        whenever(paymentIntent.isSetUpIntentPayment).thenReturn(true)
+        val useCase = IsSDKInitializedCorrectlyUseCase()
+
+        // Act
+        val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
+
+        // Assert
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `given Payment Card PaymentIntent, isSDKInitiatedCorrectly should return true`() {
+        // Arrange
+        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+        val paymentType = DojoPaymentType.PAYMENT_CARD
+        val useCase = IsSDKInitializedCorrectlyUseCase()
+
+        // Act
+        val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
+
+        // Assert
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `given non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly should return false`() {
+        // Arrange
+        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+        val paymentType = DojoPaymentType.SETUP_INTENT
+        val useCase = IsSDKInitializedCorrectlyUseCase()
+
+        // Act
+        val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
+
+        // Assert
+        assertEquals(false, result)
+    }
+}

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
@@ -2,19 +2,19 @@ package tech.dojo.pay.uisdk.domain
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
 
 class IsSDKInitializedCorrectlyUseCaseTest {
 
     @Test
-    fun `given calling isSDKInitiatedCorrectly with Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+    fun `when calling isSDKInitiatedCorrectly with Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.VIRTUAL_TERMINAL
-        whenever(paymentIntent.isVirtualTerminalPayment).thenReturn(true)
+        given(paymentIntent.isVirtualTerminalPayment).willReturn(true)
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
         // when
@@ -25,11 +25,11 @@ class IsSDKInitializedCorrectlyUseCaseTest {
     }
 
     @Test
-    fun `given calling isSDKInitiatedCorrectly with  Setup Intent PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+    fun `when calling isSDKInitiatedCorrectly with  Setup Intent PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
-        whenever(paymentIntent.isSetUpIntentPayment).thenReturn(true)
+        given(paymentIntent.isSetUpIntentPayment).willReturn(true)
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
         // when
@@ -40,7 +40,7 @@ class IsSDKInitializedCorrectlyUseCaseTest {
     }
 
     @Test
-    fun `given calling isSDKInitiatedCorrectly with  Payment Card PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+    fun `when calling isSDKInitiatedCorrectly with  Payment Card PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.PAYMENT_CARD
@@ -54,7 +54,7 @@ class IsSDKInitializedCorrectlyUseCaseTest {
     }
 
     @Test
-    fun `given calling isSDKInitiatedCorrectly  non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly then  should return false`() {
+    fun `when calling isSDKInitiatedCorrectly  non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly then  should return false`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
@@ -2,7 +2,7 @@ package tech.dojo.pay.uisdk.domain
 
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.mockito.Mockito.mock
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
@@ -10,9 +10,9 @@ import tech.dojo.pay.uisdk.entities.DojoPaymentType
 class IsSDKInitializedCorrectlyUseCaseTest {
 
     @Test
-    fun `given Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly should return true`() {
-        // Arrange
-        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+    fun `when calling isSDKInitiatedCorrectly with Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+        // Given
+        val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.VIRTUAL_TERMINAL
         whenever(paymentIntent.isVirtualTerminalPayment).thenReturn(true)
         val useCase = IsSDKInitializedCorrectlyUseCase()
@@ -25,9 +25,9 @@ class IsSDKInitializedCorrectlyUseCaseTest {
     }
 
     @Test
-    fun `given Setup Intent PaymentIntent, isSDKInitiatedCorrectly should return true`() {
-        // Arrange
-        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+    fun `when calling isSDKInitiatedCorrectly with  Setup Intent PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+        // Given
+        val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
         whenever(paymentIntent.isSetUpIntentPayment).thenReturn(true)
         val useCase = IsSDKInitializedCorrectlyUseCase()
@@ -40,9 +40,9 @@ class IsSDKInitializedCorrectlyUseCaseTest {
     }
 
     @Test
-    fun `given Payment Card PaymentIntent, isSDKInitiatedCorrectly should return true`() {
-        // Arrange
-        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+    fun `when calling isSDKInitiatedCorrectly with  Payment Card PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+        // Given
+        val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.PAYMENT_CARD
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
@@ -54,9 +54,9 @@ class IsSDKInitializedCorrectlyUseCaseTest {
     }
 
     @Test
-    fun `given non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly should return false`() {
-        // Arrange
-        val paymentIntent = mock(PaymentIntentDomainEntity::class.java)
+    fun `when calling isSDKInitiatedCorrectly  non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly then  should return false`() {
+        // Given
+        val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
         val useCase = IsSDKInitializedCorrectlyUseCase()
 

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/IsSDKInitializedCorrectlyUseCaseTest.kt
@@ -10,60 +10,60 @@ import tech.dojo.pay.uisdk.entities.DojoPaymentType
 class IsSDKInitializedCorrectlyUseCaseTest {
 
     @Test
-    fun `when calling isSDKInitiatedCorrectly with Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+    fun `given calling isSDKInitiatedCorrectly with Virtual Terminal PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.VIRTUAL_TERMINAL
         whenever(paymentIntent.isVirtualTerminalPayment).thenReturn(true)
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
-        // Act
+        // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
 
-        // Assert
+        // then
         assertEquals(true, result)
     }
 
     @Test
-    fun `when calling isSDKInitiatedCorrectly with  Setup Intent PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+    fun `given calling isSDKInitiatedCorrectly with  Setup Intent PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
         whenever(paymentIntent.isSetUpIntentPayment).thenReturn(true)
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
-        // Act
+        // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
 
-        // Assert
+        // then
         assertEquals(true, result)
     }
 
     @Test
-    fun `when calling isSDKInitiatedCorrectly with  Payment Card PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
+    fun `given calling isSDKInitiatedCorrectly with  Payment Card PaymentIntent, isSDKInitiatedCorrectly then should return true`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.PAYMENT_CARD
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
-        // Act
+        // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
 
-        // Assert
+        // then
         assertEquals(true, result)
     }
 
     @Test
-    fun `when calling isSDKInitiatedCorrectly  non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly then  should return false`() {
+    fun `given calling isSDKInitiatedCorrectly  non-matching PaymentIntent and PaymentType, isSDKInitiatedCorrectly then  should return false`() {
         // Given
         val paymentIntent: PaymentIntentDomainEntity = mock()
         val paymentType = DojoPaymentType.SETUP_INTENT
         val useCase = IsSDKInitializedCorrectlyUseCase()
 
-        // Act
+        // when
         val result = useCase.isSDKInitiatedCorrectly(paymentIntent, paymentType)
 
-        // Assert
+        // then
         assertEquals(false, result)
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -9,42 +9,32 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
+import tech.dojo.pay.sdk.card.entities.WalletSchemes
 import tech.dojo.pay.uisdk.data.entities.Amount
+import tech.dojo.pay.uisdk.data.entities.BillingAddress
+import tech.dojo.pay.uisdk.data.entities.Branding
+import tech.dojo.pay.uisdk.data.entities.Config
+import tech.dojo.pay.uisdk.data.entities.Customer
+import tech.dojo.pay.uisdk.data.entities.CustomerEmail
+import tech.dojo.pay.uisdk.data.entities.ItemLines
 import tech.dojo.pay.uisdk.data.entities.MerchantConfig
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentPayload
+import tech.dojo.pay.uisdk.data.entities.ShippingAddress
 import tech.dojo.pay.uisdk.data.entities.SupportedPaymentMethods
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.EssentialParamMissingException
+import tech.dojo.pay.uisdk.domain.entities.ItemLinesDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
 internal class PaymentIntentDomainEntityMapperTest {
     @Test
-    fun `calling apply with valid PaymentIntentPayload should map to PaymentIntentDomainEntity `() =
+    fun `given calling apply with valid PaymentIntentPayload then should map to PaymentIntentDomainEntity with all valid data`() =
         runTest {
             // arrange
-            val raw = PaymentIntentPayload(
-                id = "id",
-                clientSessionSecret = "clientSessionSecret",
-                amount = Amount(
-                    10L,
-                    "GBP",
-                ),
-                merchantConfig = MerchantConfig(supportedPaymentMethods = SupportedPaymentMethods(cardSchemes = listOf(CardsSchemes.MASTERCARD))),
-                reference = "reference",
-            )
-            val expected = PaymentIntentDomainEntity(
-                id = "id",
-                paymentToken = "clientSessionSecret",
-                amount = AmountDomainEntity(
-                    10L,
-                    "0.10",
-                    "GBP",
-                ),
-                supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD),
-                orderId = "reference",
-            )
+            val raw = createValidPaymentIntentPayload()
+            val expected = getValidPaymentIntentDomainEntity()
             // act
             val actual = PaymentIntentDomainEntityMapper().apply(raw)
             // assert
@@ -52,7 +42,7 @@ internal class PaymentIntentDomainEntityMapperTest {
         }
 
     @Test
-    fun `calling apply with invalid PaymentIntentPayload should Thrown EssentialParamMissingException `() =
+    fun `given calling apply with invalid PaymentIntentPayload should Thrown EssentialParamMissingException that contains all the missing fields`() =
         runTest {
             // arrange
             val raw = PaymentIntentPayload()
@@ -65,5 +55,87 @@ internal class PaymentIntentDomainEntityMapperTest {
             assertTrue(actual.message?.contains("amount") ?: false)
             assertTrue(actual.message?.contains("id") ?: false)
             assertTrue(actual.message?.contains("merchantConfig") ?: false)
+            assertTrue(actual.message?.contains("supportedPaymentMethods") ?: false)
+            assertTrue(actual.message?.contains("cardSchemes") ?: false)
         }
+
+    private fun createValidPaymentIntentPayload() = PaymentIntentPayload(
+        id = "id",
+        captureMode = "captureMode",
+        transactionSource = "transactionSource",
+        clientSessionSecret = "clientSessionSecret",
+        clientSessionSecretExpirationDate = "clientSessionSecretExpirationDate",
+        status = "status",
+        paymentMethods = listOf("paymentMethods"),
+        amount = Amount(
+            10L,
+            "GBP",
+        ),
+        customer = Customer(id = "id"),
+        reference = "reference",
+        merchantConfig = MerchantConfig(
+            supportedPaymentMethods = SupportedPaymentMethods(
+                cardSchemes = listOf(CardsSchemes.MASTERCARD),
+            ),
+        ),
+        paymentSource = "virtual-terminal",
+        config = Config(
+            tradingName = "tradingName",
+            branding = Branding(logoURL = "logoURL", faviconURL = "faviconURL"),
+            customerEmail = CustomerEmail(true),
+            billingAddress = BillingAddress(true),
+            shippingDetails = ShippingAddress(true),
+        ),
+        merchantInitiatedType = "merchantInitiatedType",
+        itemLines = listOf(
+            ItemLines(
+                caption = "caption",
+                amountTotal = Amount(
+                    10L,
+                    "GBP",
+                ),
+            ),
+        ),
+
+    )
+
+    private fun getValidPaymentIntentDomainEntity(): PaymentIntentDomainEntity {
+        val amountItem = Amount(
+            10L,
+            "GBP",
+        )
+        val id = "id"
+        val clientSessionSecret = "clientSessionSecret"
+        val amount = AmountDomainEntity(10L, "0.10", "GBP")
+        val supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD)
+        val supportedWalletSchemes = emptyList<WalletSchemes>()
+        val itemLines = listOf(ItemLinesDomainEntity("caption", amountItem))
+        val customerId = "id"
+        val collectionEmailRequired = true
+        val isVirtualTerminalPayment = true
+        val collectionBillingAddressRequired = true
+        val isPreAuthPayment = false
+        val orderId = "reference"
+        val collectionShippingAddressRequired = true
+        val isSetUpIntentPayment = true
+        val merchantName = "tradingName"
+
+        return PaymentIntentDomainEntity(
+            id = id,
+            paymentToken = clientSessionSecret,
+            amount = amount,
+            supportedCardsSchemes = supportedCardsSchemes,
+            supportedWalletSchemes = supportedWalletSchemes,
+            itemLines = itemLines,
+            customerId = customerId,
+            collectionEmailRequired = collectionEmailRequired,
+            isVirtualTerminalPayment = isVirtualTerminalPayment,
+            collectionBillingAddressRequired = collectionBillingAddressRequired,
+            isPreAuthPayment = isPreAuthPayment,
+            orderId = orderId,
+            collectionShippingAddressRequired = collectionShippingAddressRequired,
+            isSetUpIntentPayment = isSetUpIntentPayment,
+            merchantName = merchantName,
+        )
+    }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -29,10 +29,10 @@ internal class PaymentIntentDomainEntityMapperTest {
                 clientSessionSecret = "clientSessionSecret",
                 amount = Amount(
                     10L,
-                    "GBP"
+                    "GBP",
                 ),
                 merchantConfig = MerchantConfig(supportedPaymentMethods = SupportedPaymentMethods(cardSchemes = listOf(CardsSchemes.MASTERCARD))),
-                reference = "reference"
+                reference = "reference",
             )
             val expected = PaymentIntentDomainEntity(
                 id = "id",
@@ -40,10 +40,10 @@ internal class PaymentIntentDomainEntityMapperTest {
                 amount = AmountDomainEntity(
                     10L,
                     "0.10",
-                    "GBP"
+                    "GBP",
                 ),
                 supportedCardsSchemes = listOf(CardsSchemes.MASTERCARD),
-                orderId = "reference"
+                orderId = "reference",
             )
             // act
             val actual = PaymentIntentDomainEntityMapper().apply(raw)
@@ -58,7 +58,7 @@ internal class PaymentIntentDomainEntityMapperTest {
             val raw = PaymentIntentPayload()
             // act
             val actual = assertThrows(
-                EssentialParamMissingException::class.java
+                EssentialParamMissingException::class.java,
             ) { PaymentIntentDomainEntityMapper().apply(raw) }
             // assert
             assertTrue(actual.message?.contains("clientSessionSecret") ?: false)

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -30,7 +30,7 @@ import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 @RunWith(MockitoJUnitRunner::class)
 internal class PaymentIntentDomainEntityMapperTest {
     @Test
-    fun `given calling apply with valid PaymentIntentPayload then should map to PaymentIntentDomainEntity with all valid data`() =
+    fun `when calling apply with valid PaymentIntentPayload then should map to PaymentIntentDomainEntity with all valid data`() =
         runTest {
             // arrange
             val raw = createValidPaymentIntentPayload()
@@ -42,7 +42,7 @@ internal class PaymentIntentDomainEntityMapperTest {
         }
 
     @Test
-    fun `given calling apply with invalid PaymentIntentPayload should Thrown EssentialParamMissingException that contains all the missing fields`() =
+    fun `when calling apply with invalid PaymentIntentPayload should Thrown EssentialParamMissingException that contains all the missing fields`() =
         runTest {
             // arrange
             val raw = PaymentIntentPayload()

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -56,25 +56,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             // act
             PaymentFlowViewModel(
                 paymentId,
@@ -126,25 +110,9 @@ internal class PaymentFlowViewModelTest {
             val expected = PaymentFlowNavigationEvents.CLoseFlowWithInternalError
 
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(false)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -166,25 +134,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -206,25 +158,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -245,25 +181,9 @@ internal class PaymentFlowViewModelTest {
     fun `calling onBackClicked should emits OnBack`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
+            MutableStateFlow(successPaymentIntent())
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
         whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
-                ),
-            ),
-        )
         val expected = PaymentFlowNavigationEvents.OnBack
         // act
         val viewModel = PaymentFlowViewModel(
@@ -287,25 +207,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             val expected =
                 PaymentFlowNavigationEvents.PaymentMethodsCheckOutWithSelectedPaymentMethod()
             // act
@@ -329,25 +233,9 @@ internal class PaymentFlowViewModelTest {
     fun `calling onCloseFlowClicked should emits OnCloseFlow`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
+            MutableStateFlow(successPaymentIntent())
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
         whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
-                ),
-            ),
-        )
         val expected = PaymentFlowNavigationEvents.OnCloseFlow
         // act
         val viewModel = PaymentFlowViewModel(
@@ -371,25 +259,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             val expected =
                 PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
             // act
@@ -414,25 +286,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             val expected = PaymentFlowNavigationEvents.PaymentResult(
                 DojoPaymentResult.SDK_INTERNAL_ERROR,
                 false,
@@ -459,25 +315,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             val expected =
                 PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.FAILED, false)
             // act
@@ -501,25 +341,9 @@ internal class PaymentFlowViewModelTest {
     fun `calling navigateToCardDetailsCheckoutScreen should emits CardDetailsCheckout`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
+            MutableStateFlow(successPaymentIntent())
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
         whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
-                ),
-            ),
-        )
         val expected = PaymentFlowNavigationEvents.CardDetailsCheckout
         // act
         val viewModel = PaymentFlowViewModel(
@@ -544,25 +368,9 @@ internal class PaymentFlowViewModelTest {
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-                MutableStateFlow(null)
+                MutableStateFlow(successPaymentIntent())
             whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
             whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
-            paymentIntentFakeFlow.tryEmit(
-                PaymentIntentResult.Success(
-                    result = PaymentIntentDomainEntity(
-                        "id",
-                        "token",
-                        AmountDomainEntity(
-                            10L,
-                            "100",
-                            "GBP",
-                        ),
-                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                        collectionBillingAddressRequired = true,
-                        customerId = "customerId",
-                    ),
-                ),
-            )
             val expected = PaymentFlowNavigationEvents.ManagePaymentMethods("customerId")
             // act
             val viewModel = PaymentFlowViewModel(
@@ -736,4 +544,19 @@ internal class PaymentFlowViewModelTest {
             // assert
             Assert.assertEquals(expected, actual)
         }
+
+    private fun successPaymentIntent() = PaymentIntentResult.Success(
+        result = PaymentIntentDomainEntity(
+            "id",
+            "token",
+            AmountDomainEntity(
+                10L,
+                "100",
+                "GBP",
+            ),
+            supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+            collectionBillingAddressRequired = true,
+            customerId = "customerId",
+        ),
+    )
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -10,9 +10,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
 import tech.dojo.pay.uisdk.core.MainCoroutineScopeRule
@@ -52,13 +52,13 @@ internal class PaymentFlowViewModelTest {
     private val isSDKInitializedCorrectlyUseCase: IsSDKInitializedCorrectlyUseCase = mock()
 
     @Test
-    fun `initialize view model with Success state from payment intent should call fetch payment methods `() =
+    fun `when initialize view model with Success state from payment intent then should call fetch payment methods `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             // act
             PaymentFlowViewModel(
                 paymentId,
@@ -79,12 +79,12 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `initialize view model with FetchFailure state from payment intent should close the flow with Internal error `() =
+    fun `when initialize view model with FetchFailure state from payment intent then should close the flow with Internal error `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(null)
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
             paymentIntentFakeFlow.tryEmit(PaymentIntentResult.FetchFailure)
             val expected = PaymentFlowNavigationEvents.CLoseFlowWithInternalError
             // act
@@ -104,15 +104,15 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `initialize view model with Success state from payment intent and false from isSDKInitializedCorrectlyUseCase should close the flow with Internal error `() =
+    fun `when initialize view model with Success state from payment intent and false from isSDKInitializedCorrectlyUseCase should close the flow with Internal error `() =
         runTest {
             // arrange
             val expected = PaymentFlowNavigationEvents.CLoseFlowWithInternalError
 
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(false)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(false)
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -130,13 +130,13 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling updatePaymentState should call updatePaymentSate from updatePaymentStateUseCase`() =
+    fun `when calling updatePaymentState should call updatePaymentSate from updatePaymentStateUseCase`() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -154,13 +154,13 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling updateGpayPaymentState should call updateGpayPaymentSate from updatePaymentStateUseCase`() =
+    fun `when calling updateGpayPaymentState should call updateGpayPaymentSate from updatePaymentStateUseCase`() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -178,12 +178,12 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling onBackClicked should emits OnBack`() = runTest {
+    fun `when calling onBackClicked should emits OnBack`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
             MutableStateFlow(successPaymentIntent())
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
         val expected = PaymentFlowNavigationEvents.OnBack
         // act
         val viewModel = PaymentFlowViewModel(
@@ -203,13 +203,13 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `calling onBackClickedWithSavedPaymentMethod should emits PaymentMethodsCheckOutWithSelectedPaymentMethod`() =
+    fun `when calling onBackClickedWithSavedPaymentMethod should emits PaymentMethodsCheckOutWithSelectedPaymentMethod`() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             val expected =
                 PaymentFlowNavigationEvents.PaymentMethodsCheckOutWithSelectedPaymentMethod()
             // act
@@ -230,12 +230,12 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling onCloseFlowClicked should emits OnCloseFlow`() = runTest {
+    fun `when calling onCloseFlowClicked should emits OnCloseFlow`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
             MutableStateFlow(successPaymentIntent())
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
         val expected = PaymentFlowNavigationEvents.OnCloseFlow
         // act
         val viewModel = PaymentFlowViewModel(
@@ -255,13 +255,13 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `calling navigateToPaymentResult with SUCCESSFUL should emits PaymentResult with popBackStack as true `() =
+    fun `when calling navigateToPaymentResult with SUCCESSFUL should emits PaymentResult with popBackStack as true `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             val expected =
                 PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
             // act
@@ -282,13 +282,13 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling navigateToPaymentResult with SDK_INTERNAL_ERROR should emits PaymentResult with popBackStack as false `() =
+    fun `when calling navigateToPaymentResult with SDK_INTERNAL_ERROR should emits PaymentResult with popBackStack as false `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             val expected = PaymentFlowNavigationEvents.PaymentResult(
                 DojoPaymentResult.SDK_INTERNAL_ERROR,
                 false,
@@ -311,13 +311,13 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling navigateToPaymentResult with FAILED should emits PaymentResult with popBackStack as false `() =
+    fun `when calling navigateToPaymentResult with FAILED should emits PaymentResult with popBackStack as false `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             val expected =
                 PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.FAILED, false)
             // act
@@ -338,12 +338,12 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `calling navigateToCardDetailsCheckoutScreen should emits CardDetailsCheckout`() = runTest {
+    fun `when calling navigateToCardDetailsCheckoutScreen should emits CardDetailsCheckout`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
             MutableStateFlow(successPaymentIntent())
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
         val expected = PaymentFlowNavigationEvents.CardDetailsCheckout
         // act
         val viewModel = PaymentFlowViewModel(
@@ -364,13 +364,13 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `calling navigateToManagePaymentMethods should emits ManagePaymentMethods with customer id `() =
+    fun `when calling navigateToManagePaymentMethods should emits ManagePaymentMethods with customer id `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-            whenever(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).thenReturn(true)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
             val expected = PaymentFlowNavigationEvents.ManagePaymentMethods("customerId")
             // act
             val viewModel = PaymentFlowViewModel(
@@ -390,7 +390,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `call isPaymentInSandBoxEnvironment with prod paymentID should return false `() = runTest {
+    fun `when call isPaymentInSandBoxEnvironment with prod paymentID should return false `() = runTest {
         // arrange
         val viewModel = PaymentFlowViewModel(
             paymentId,
@@ -409,7 +409,7 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `call isPaymentInSandBoxEnvironment with sankBox paymentID should return true `() =
+    fun `when call isPaymentInSandBoxEnvironment with sankBox paymentID should return true `() =
         runTest {
             // arrange
             val viewModel = PaymentFlowViewModel(
@@ -429,7 +429,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `call getCustomColorPalette with isDarkModeEnabled as true  should return darkColorPalette `() =
+    fun `when call getCustomColorPalette with isDarkModeEnabled as true  should return darkColorPalette `() =
         runTest {
             // arrange
             val expected = darkColorPalette(DarkColorPalette())
@@ -453,7 +453,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `call getCustomColorPalette with isDarkModeEnabled as false should return LightColorPalette `() =
+    fun `when call getCustomColorPalette with isDarkModeEnabled as false should return LightColorPalette `() =
         runTest {
             // arrange
             val expected = lightColorPalette(LightColorPalette())
@@ -477,7 +477,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `given calling getFlowStartDestination with PAYMENT_CARD type the start destination should be PaymentMethodCheckout`() =
+    fun `when  calling getFlowStartDestination with PAYMENT_CARD type the start destination should be PaymentMethodCheckout`() =
         runTest {
             // arrange
             val expected = PaymentFlowScreens.PaymentMethodCheckout
@@ -500,7 +500,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `given calling getFlowStartDestination with CARD_ON_FILE type the start destination should be CardDetailsCheckout`() =
+    fun `when calling getFlowStartDestination with CARD_ON_FILE type the start destination should be CardDetailsCheckout`() =
         runTest {
             // arrange
             val expected = PaymentFlowScreens.CardDetailsCheckout
@@ -523,7 +523,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `given calling getFlowStartDestination with VIRTUAL_TERMINAL type the start destination should be VirtualTerminalCheckOutScreen`() =
+    fun `when calling getFlowStartDestination with VIRTUAL_TERMINAL type the start destination should be VirtualTerminalCheckOutScreen`() =
         runTest {
             // arrange
             val expected = PaymentFlowScreens.VirtualTerminalCheckOutScreen

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -106,7 +106,11 @@ internal class PaymentFlowViewModelTest {
                 updatePaymentStateUseCase,
             )
             // assert
-            verify(fetchPaymentMethodsUseCase).fetchPaymentMethodsWithPaymentType(DojoPaymentType.PAYMENT_CARD, "customerId", customerSecret)
+            verify(fetchPaymentMethodsUseCase).fetchPaymentMethodsWithPaymentType(
+                DojoPaymentType.PAYMENT_CARD,
+                "customerId",
+                customerSecret,
+            )
         }
 
     @Test
@@ -225,43 +229,45 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `calling onBackClickedWithSavedPaymentMethod should emits PaymentMethodsCheckOutWithSelectedPaymentMethod`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
+    fun `calling onBackClickedWithSavedPaymentMethod should emits PaymentMethodsCheckOutWithSelectedPaymentMethod`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        customerId = "customerId",
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
                 ),
-            ),
-        )
-        val expected = PaymentFlowNavigationEvents.PaymentMethodsCheckOutWithSelectedPaymentMethod()
-        // act
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        viewModel.onBackClickedWithSavedPaymentMethod()
-        val actual = viewModel.navigationEvent.value
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            )
+            val expected =
+                PaymentFlowNavigationEvents.PaymentMethodsCheckOutWithSelectedPaymentMethod()
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            viewModel.onBackClickedWithSavedPaymentMethod()
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
     fun `calling onCloseFlowClicked should emits OnCloseFlow`() = runTest {
@@ -303,121 +309,129 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `calling navigateToPaymentResult with SUCCESSFUL should emits PaymentResult with popBackStack as true `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
+    fun `calling navigateToPaymentResult with SUCCESSFUL should emits PaymentResult with popBackStack as true `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        customerId = "customerId",
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
                 ),
-            ),
-        )
-        val expected = PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
-        // act
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        viewModel.navigateToPaymentResult(DojoPaymentResult.SUCCESSFUL)
-        val actual = viewModel.navigationEvent.value
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            )
+            val expected =
+                PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            viewModel.navigateToPaymentResult(DojoPaymentResult.SUCCESSFUL)
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
-    fun `calling navigateToPaymentResult with SDK_INTERNAL_ERROR should emits PaymentResult with popBackStack as false `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
+    fun `calling navigateToPaymentResult with SDK_INTERNAL_ERROR should emits PaymentResult with popBackStack as false `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        customerId = "customerId",
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
                 ),
-            ),
-        )
-        val expected = PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SDK_INTERNAL_ERROR, false)
-        // act
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        viewModel.navigateToPaymentResult(DojoPaymentResult.SDK_INTERNAL_ERROR)
-        val actual = viewModel.navigationEvent.value
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            )
+            val expected = PaymentFlowNavigationEvents.PaymentResult(
+                DojoPaymentResult.SDK_INTERNAL_ERROR,
+                false,
+            )
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            viewModel.navigateToPaymentResult(DojoPaymentResult.SDK_INTERNAL_ERROR)
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
-    fun `calling navigateToPaymentResult with FAILED should emits PaymentResult with popBackStack as false `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
+    fun `calling navigateToPaymentResult with FAILED should emits PaymentResult with popBackStack as false `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        customerId = "customerId",
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
                 ),
-            ),
-        )
-        val expected = PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.FAILED, false)
-        // act
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        viewModel.navigateToPaymentResult(DojoPaymentResult.FAILED)
-        val actual = viewModel.navigationEvent.value
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            )
+            val expected =
+                PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.FAILED, false)
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            viewModel.navigateToPaymentResult(DojoPaymentResult.FAILED)
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
     fun `calling navigateToCardDetailsCheckoutScreen should emits CardDetailsCheckout`() = runTest {
@@ -459,43 +473,44 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `calling navigateToManagePaymentMethods should emits ManagePaymentMethods with customer id `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
+    fun `calling navigateToManagePaymentMethods should emits ManagePaymentMethods with customer id `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        customerId = "customerId",
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    customerId = "customerId",
                 ),
-            ),
-        )
-        val expected = PaymentFlowNavigationEvents.ManagePaymentMethods("customerId")
-        // act
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        viewModel.navigateToManagePaymentMethods()
-        val actual = viewModel.navigationEvent.value
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            )
+            val expected = PaymentFlowNavigationEvents.ManagePaymentMethods("customerId")
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            viewModel.navigateToManagePaymentMethods()
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
     fun `call isPaymentInSandBoxEnvironment with prod paymentID should return false `() = runTest {
@@ -516,121 +531,133 @@ internal class PaymentFlowViewModelTest {
     }
 
     @Test
-    fun `call isPaymentInSandBoxEnvironment with sankBox paymentID should return true `() = runTest {
-        // arrange
-        val viewModel = PaymentFlowViewModel(
-            "Sandbox_paymentId",
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        // act
-        val actual = viewModel.isPaymentInSandBoxEnvironment()
-        // assert
-        Assert.assertTrue(actual)
-    }
+    fun `call isPaymentInSandBoxEnvironment with sankBox paymentID should return true `() =
+        runTest {
+            // arrange
+            val viewModel = PaymentFlowViewModel(
+                "Sandbox_paymentId",
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            // act
+            val actual = viewModel.isPaymentInSandBoxEnvironment()
+            // assert
+            Assert.assertTrue(actual)
+        }
 
     @Test
-    fun `call getCustomColorPalette with isDarkModeEnabled as true  should return darkColorPalette `() = runTest {
-        // arrange
-        val expected = darkColorPalette(DarkColorPalette())
-        val viewModel = PaymentFlowViewModel(
-            "Sandbox_paymentId",
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        // act
-        val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = true)
-        // assert
-        Assert.assertEquals(expected.primarySurfaceBackgroundColor, actual.primarySurfaceBackgroundColor)
-    }
+    fun `call getCustomColorPalette with isDarkModeEnabled as true  should return darkColorPalette `() =
+        runTest {
+            // arrange
+            val expected = darkColorPalette(DarkColorPalette())
+            val viewModel = PaymentFlowViewModel(
+                "Sandbox_paymentId",
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            // act
+            val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = true)
+            // assert
+            Assert.assertEquals(
+                expected.primarySurfaceBackgroundColor,
+                actual.primarySurfaceBackgroundColor,
+            )
+        }
 
     @Test
-    fun `call getCustomColorPalette with isDarkModeEnabled as false should return LightColorPalette `() = runTest {
-        // arrange
-        val expected = lightColorPalette(LightColorPalette())
-        val viewModel = PaymentFlowViewModel(
-            "Sandbox_paymentId",
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-        // act
-        val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = false)
-        // assert
-        Assert.assertEquals(expected.primarySurfaceBackgroundColor, actual.primarySurfaceBackgroundColor)
-    }
+    fun `call getCustomColorPalette with isDarkModeEnabled as false should return LightColorPalette `() =
+        runTest {
+            // arrange
+            val expected = lightColorPalette(LightColorPalette())
+            val viewModel = PaymentFlowViewModel(
+                "Sandbox_paymentId",
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+            // act
+            val actual = viewModel.getCustomColorPalette(isDarkModeEnabled = false)
+            // assert
+            Assert.assertEquals(
+                expected.primarySurfaceBackgroundColor,
+                actual.primarySurfaceBackgroundColor,
+            )
+        }
 
     @Test
-    fun`given calling getFlowStartDestination with PAYMENT_CARD type the start destination should be PaymentMethodCheckout`() = runTest {
-        // arrange
-        val expected = PaymentFlowScreens.PaymentMethodCheckout
-        paymentType = DojoPaymentType.PAYMENT_CARD
-        val viewModel = PaymentFlowViewModel(
-            "Sandbox_paymentId",
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
+    fun `given calling getFlowStartDestination with PAYMENT_CARD type the start destination should be PaymentMethodCheckout`() =
+        runTest {
+            // arrange
+            val expected = PaymentFlowScreens.PaymentMethodCheckout
+            paymentType = DojoPaymentType.PAYMENT_CARD
+            val viewModel = PaymentFlowViewModel(
+                "Sandbox_paymentId",
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
 
-        // act
-        val actual = viewModel.getFlowStartDestination()
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
-
-    @Test
-    fun`given calling getFlowStartDestination with CARD_ON_FILE type the start destination should be CardDetailsCheckout`() = runTest {
-        // arrange
-        val expected = PaymentFlowScreens.CardDetailsCheckout
-        paymentType = DojoPaymentType.CARD_ON_FILE
-        val viewModel = PaymentFlowViewModel(
-            "Sandbox_paymentId",
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
-
-        // act
-        val actual = viewModel.getFlowStartDestination()
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            // act
+            val actual = viewModel.getFlowStartDestination()
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
-    fun`given calling getFlowStartDestination with VIRTUAL_TERMINAL type the start destination should be VirtualTerminalCheckOutScreen`() = runTest {
-        // arrange
-        val expected = PaymentFlowScreens.VirtualTerminalCheckOutScreen
-        paymentType = DojoPaymentType.VIRTUAL_TERMINAL
-        val viewModel = PaymentFlowViewModel(
-            "Sandbox_paymentId",
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-        )
+    fun `given calling getFlowStartDestination with CARD_ON_FILE type the start destination should be CardDetailsCheckout`() =
+        runTest {
+            // arrange
+            val expected = PaymentFlowScreens.CardDetailsCheckout
+            paymentType = DojoPaymentType.SETUP_INTENT
+            val viewModel = PaymentFlowViewModel(
+                "Sandbox_paymentId",
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
 
-        // act
-        val actual = viewModel.getFlowStartDestination()
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            // act
+            val actual = viewModel.getFlowStartDestination()
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `given calling getFlowStartDestination with VIRTUAL_TERMINAL type the start destination should be VirtualTerminalCheckOutScreen`() =
+        runTest {
+            // arrange
+            val expected = PaymentFlowScreens.VirtualTerminalCheckOutScreen
+            paymentType = DojoPaymentType.VIRTUAL_TERMINAL
+            val viewModel = PaymentFlowViewModel(
+                "Sandbox_paymentId",
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+            )
+
+            // act
+            val actual = viewModel.getFlowStartDestination()
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -11,6 +11,7 @@ import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedC
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
 
 class CardCheckOutFullCardPaymentPayloadMapperTest {
+    private val isStartDestination: Boolean = false
 
     @Test
     fun `given calling getPaymentPayLoad with email and billing enabled should returns correct payload with email and billing address`() {
@@ -30,7 +31,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val paymentPayload = mapper.getPaymentPayLoad(currentState)
+        val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
 
         // Assert
         val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
@@ -70,7 +71,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val paymentPayload = mapper.getPaymentPayLoad(currentState)
+        val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
 
         // Assert
         val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
@@ -106,7 +107,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val paymentPayload = mapper.getPaymentPayLoad(currentState)
+        val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
 
         // Assert
         val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
@@ -139,7 +140,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryMonth = mapper.getPaymentPayLoad(currentState).cardDetails.expiryMonth
+        val expiryMonth = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
 
         // Assert
         assertEquals("12", expiryMonth)
@@ -159,7 +160,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cvvInputFieldState.value } returns "123"
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryMonth = mapper.getPaymentPayLoad(currentState).cardDetails.expiryMonth
+        val expiryMonth = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
 
         // Assert
         assertEquals("", expiryMonth)
@@ -179,7 +180,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cvvInputFieldState.value } returns "123"
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryYear = mapper.getPaymentPayLoad(currentState).cardDetails.expiryYear
+        val expiryYear = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
 
         // Assert
         assertEquals("25", expiryYear)
@@ -200,7 +201,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryYear = mapper.getPaymentPayLoad(currentState).cardDetails.expiryYear
+        val expiryYear = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
 
         // Assert
         assertEquals("", expiryYear)

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -1,0 +1,208 @@
+package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
+import tech.dojo.pay.sdk.card.entities.DojoCardDetails
+import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
+
+class CardCheckOutFullCardPaymentPayloadMapperTest {
+
+    @Test
+    fun `given calling getPaymentPayLoad with email and billing enabled should returns correct payload with email and billing address`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.isEmailInputFieldRequired } returns true
+        every { currentState.emailInputField.value } returns "test@example.com"
+        every { currentState.isBillingCountryFieldRequired } returns true
+        every { currentState.currentSelectedCountry.countryCode } returns "US"
+        every { currentState.isPostalCodeFieldRequired } returns true
+        every { currentState.postalCodeField.value } returns "12345"
+        every { currentState.checkBoxItem.isChecked } returns true
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.cvvInputFieldState.value } returns "123"
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val paymentPayload = mapper.getPaymentPayLoad(currentState)
+
+        // Assert
+        val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
+            userEmailAddress = "test@example.com",
+            billingAddress = DojoAddressDetails(countryCode = "US", postcode = "12345"),
+            savePaymentMethod = true,
+            cardDetails = DojoCardDetails(
+                cardNumber = "1234567812345678",
+                cardName = "John Doe",
+                expiryMonth = "12",
+                expiryYear = "25",
+                cv2 = "123",
+            ),
+        )
+        assertEquals(expectedPayload, paymentPayload)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with email enabled and billing is disabled should returns correct payload with email but without billing address`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.isEmailInputFieldRequired } returns true
+        every { currentState.emailInputField.value } returns "test@example.com"
+        every { currentState.isBillingCountryFieldRequired } returns false
+        every { currentState.isPostalCodeFieldRequired } returns false
+        every { currentState.postalCodeField.value } returns "12345"
+        every { currentState.checkBoxItem.isChecked } returns true
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.currentSelectedCountry } returns SupportedCountriesViewEntity(
+            "",
+            "",
+            false,
+        )
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val paymentPayload = mapper.getPaymentPayLoad(currentState)
+
+        // Assert
+        val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
+            userEmailAddress = "test@example.com",
+            billingAddress = DojoAddressDetails(
+                null,
+                null,
+            ), // Billing address is not required, so it should be null
+            savePaymentMethod = true,
+            cardDetails = DojoCardDetails(
+                cardNumber = "1234567812345678",
+                cardName = "John Doe",
+                expiryMonth = "12",
+                expiryYear = "25",
+                cv2 = "123",
+            ),
+        )
+        assertEquals(expectedPayload, paymentPayload)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with email and billing is disabled should  returns correct payload without email and billing address`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.isEmailInputFieldRequired } returns false
+        every { currentState.isBillingCountryFieldRequired } returns false
+        every { currentState.isPostalCodeFieldRequired } returns false
+        every { currentState.checkBoxItem.isChecked } returns false
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.cvvInputFieldState.value } returns "123"
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val paymentPayload = mapper.getPaymentPayLoad(currentState)
+
+        // Assert
+        val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
+            userEmailAddress = null,
+            billingAddress = DojoAddressDetails(null, null),
+            savePaymentMethod = false,
+            cardDetails = DojoCardDetails(
+                cardNumber = "1234567812345678",
+                cardName = "John Doe",
+                expiryMonth = "12",
+                expiryYear = "25",
+                cv2 = "123",
+            ),
+        )
+        assertEquals(expectedPayload, paymentPayload)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with valid month should returns correct month`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.isEmailInputFieldRequired } returns false
+        every { currentState.isBillingCountryFieldRequired } returns false
+        every { currentState.isPostalCodeFieldRequired } returns false
+        every { currentState.checkBoxItem.isChecked } returns false
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.cvvInputFieldState.value } returns "123"
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val expiryMonth = mapper.getPaymentPayLoad(currentState).cardDetails.expiryMonth
+
+        // Assert
+        assertEquals("12", expiryMonth)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with blank month should returns empty string`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.cardExpireDateInputField.value } returns ""
+        every { currentState.isEmailInputFieldRequired } returns false
+        every { currentState.isBillingCountryFieldRequired } returns false
+        every { currentState.isPostalCodeFieldRequired } returns false
+        every { currentState.checkBoxItem.isChecked } returns false
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cvvInputFieldState.value } returns "123"
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val expiryMonth = mapper.getPaymentPayLoad(currentState).cardDetails.expiryMonth
+
+        // Assert
+        assertEquals("", expiryMonth)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with valid year should returns correct year`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.isEmailInputFieldRequired } returns false
+        every { currentState.isBillingCountryFieldRequired } returns false
+        every { currentState.isPostalCodeFieldRequired } returns false
+        every { currentState.checkBoxItem.isChecked } returns false
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cvvInputFieldState.value } returns "123"
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val expiryYear = mapper.getPaymentPayLoad(currentState).cardDetails.expiryYear
+
+        // Assert
+        assertEquals("25", expiryYear)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with blank year should returns empty string`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.cardExpireDateInputField.value } returns ""
+        every { currentState.isEmailInputFieldRequired } returns false
+        every { currentState.isBillingCountryFieldRequired } returns false
+        every { currentState.isPostalCodeFieldRequired } returns false
+        every { currentState.checkBoxItem.isChecked } returns false
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cvvInputFieldState.value } returns "123"
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val expiryYear = mapper.getPaymentPayLoad(currentState).cardDetails.expiryYear
+
+        // Assert
+        assertEquals("", expiryYear)
+    }
+}

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -23,7 +23,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with email and billing enabled then should returns correct payload with email and billing address`() {
+    fun `given calling getPaymentPayLoad with email and billing enabled then should returns correct payload with email and billing address`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
@@ -77,7 +77,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with email enabled and billing is disabled then should returns correct payload with email but without billing address`() {
+    fun `given calling getPaymentPayLoad with email enabled and billing is disabled then should returns correct payload with email but without billing address`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
@@ -135,7 +135,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with email and billing is disabled then should returns correct payload without email and billing address`() {
+    fun `given calling getPaymentPayLoad with email and billing is disabled then should returns correct payload without email and billing address`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
@@ -174,7 +174,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with valid month then should returns correct month`() {
+    fun `given calling getPaymentPayLoad with valid month then should returns correct month`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
@@ -202,7 +202,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with blank month then should returns empty string`() {
+    fun `given calling getPaymentPayLoad with blank month then should returns empty string`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
@@ -230,7 +230,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with valid year then should returns correct year`() {
+    fun `given calling getPaymentPayLoad with valid year then should returns correct year`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
@@ -258,7 +258,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when  calling getPaymentPayLoad with blank year then should returns empty string`() {
+    fun `given calling getPaymentPayLoad with blank year then should returns empty string`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
@@ -286,7 +286,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with isStartDestination as true then should returns correct payload with savePaymentMethod as null and mitConsentGiven as checkBox state`() {
+    fun `given calling getPaymentPayLoad with isStartDestination as true then should returns correct payload with savePaymentMethod as null and mitConsentGiven as checkBox state`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
@@ -339,7 +339,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `when calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible then  should returns correct payload with savePaymentMethod as null`() {
+    fun `given calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible then  should returns correct payload with savePaymentMethod as null`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
         whenever(currentState.isEmailInputFieldRequired).thenReturn(true)

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -28,6 +28,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cardHolderInputField.value } returns "John Doe"
         every { currentState.cardExpireDateInputField.value } returns "1225"
         every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
@@ -68,6 +69,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
             "",
             false,
         )
+        every { currentState.checkBoxItem.isVisible } returns true
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
@@ -104,6 +106,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cardHolderInputField.value } returns "John Doe"
         every { currentState.cardExpireDateInputField.value } returns "1225"
         every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
@@ -137,6 +140,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cardHolderInputField.value } returns "John Doe"
         every { currentState.cardExpireDateInputField.value } returns "1225"
         every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
@@ -158,6 +162,8 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cardNumberInputField.value } returns "1234567812345678"
         every { currentState.cardHolderInputField.value } returns "John Doe"
         every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
+
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
         val expiryMonth = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
@@ -178,6 +184,8 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cardNumberInputField.value } returns "1234567812345678"
         every { currentState.cardHolderInputField.value } returns "John Doe"
         every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
+
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
         val expiryYear = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
@@ -198,6 +206,7 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
         every { currentState.cardNumberInputField.value } returns "1234567812345678"
         every { currentState.cardHolderInputField.value } returns "John Doe"
         every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
 
         // Act
         val mapper = CardCheckOutFullCardPaymentPayloadMapper()
@@ -205,5 +214,87 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
 
         // Assert
         assertEquals("", expiryYear)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with isStartDestination as true  should returns correct payload with savePaymentMethod as null and mitConsentGiven as checkBox state`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.isEmailInputFieldRequired } returns true
+        every { currentState.emailInputField.value } returns "test@example.com"
+        every { currentState.isBillingCountryFieldRequired } returns true
+        every { currentState.currentSelectedCountry.countryCode } returns "US"
+        every { currentState.isPostalCodeFieldRequired } returns true
+        every { currentState.postalCodeField.value } returns "12345"
+        every { currentState.checkBoxItem.isChecked } returns true
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns true
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val paymentPayload = mapper.getPaymentPayLoad(
+            currentState = currentState,
+            isStartDestination = true,
+        )
+
+        // Assert
+        val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
+            userEmailAddress = "test@example.com",
+            billingAddress = DojoAddressDetails(countryCode = "US", postcode = "12345"),
+            savePaymentMethod = null,
+            cardDetails = DojoCardDetails(
+                cardNumber = "1234567812345678",
+                cardName = "John Doe",
+                expiryMonth = "12",
+                expiryYear = "25",
+                cv2 = "123",
+                mitConsentGiven = true,
+            ),
+        )
+        assertEquals(expectedPayload, paymentPayload)
+    }
+
+    @Test
+    fun `given calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible  should returns correct payload with savePaymentMethod as null`() {
+        // Arrange
+        val currentState = mockk<CardDetailsCheckoutState>()
+        every { currentState.isEmailInputFieldRequired } returns true
+        every { currentState.emailInputField.value } returns "test@example.com"
+        every { currentState.isBillingCountryFieldRequired } returns true
+        every { currentState.currentSelectedCountry.countryCode } returns "US"
+        every { currentState.isPostalCodeFieldRequired } returns true
+        every { currentState.postalCodeField.value } returns "12345"
+        every { currentState.checkBoxItem.isChecked } returns true
+        every { currentState.cardNumberInputField.value } returns "1234567812345678"
+        every { currentState.cardHolderInputField.value } returns "John Doe"
+        every { currentState.cardExpireDateInputField.value } returns "1225"
+        every { currentState.cvvInputFieldState.value } returns "123"
+        every { currentState.checkBoxItem.isVisible } returns false
+
+        // Act
+        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+        val paymentPayload = mapper.getPaymentPayLoad(
+            currentState = currentState,
+            isStartDestination = false,
+        )
+
+        // Assert
+        val expectedPayload = DojoCardPaymentPayLoad.FullCardPaymentPayload(
+            userEmailAddress = "test@example.com",
+            billingAddress = DojoAddressDetails(countryCode = "US", postcode = "12345"),
+            savePaymentMethod = null,
+            cardDetails = DojoCardDetails(
+                cardNumber = "1234567812345678",
+                cardName = "John Doe",
+                expiryMonth = "12",
+                expiryYear = "25",
+                cv2 = "123",
+                mitConsentGiven = null,
+            ),
+        )
+        assertEquals(expectedPayload, paymentPayload)
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -3,7 +3,7 @@ package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mockito.kotlin.given
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
@@ -25,37 +25,38 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with email and billing enabled then should returns correct payload with email and billing address`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(true)
-        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
-        given(currentState.isBillingCountryFieldRequired).willReturn(true)
-        given(currentState.isPostalCodeFieldRequired).willReturn(true)
-        given(currentState.currentSelectedCountry).willReturn(
-            SupportedCountriesViewEntity(
-                countryCode = "US",
-                countryName = "USA",
-                isPostalCodeEnabled = false,
-            ),
-        )
-        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "",
-            ),
-        )
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = true,
-                messageText = "",
-            ),
-        )
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(true)
+            on { emailInputField }.doReturn(InputFieldState("test@example.com"))
+            on { isBillingCountryFieldRequired }.doReturn(true)
+            on { isPostalCodeFieldRequired }.doReturn(true)
+            on { currentSelectedCountry }.doReturn(
+                SupportedCountriesViewEntity(
+                    countryCode = "US",
+                    countryName = "USA",
+                    isPostalCodeEnabled = false,
+                ),
+            )
+            on { postalCodeField }.doReturn(InputFieldState("12345"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "",
+                ),
+            )
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = true,
+                    messageText = "",
+                ),
+            )
+        }
 
         // Act
         val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
@@ -79,38 +80,38 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with email enabled and billing is disabled then should returns correct payload with email but without billing address`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(true)
-        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
-        given(currentState.isBillingCountryFieldRequired).willReturn(false)
-        given(currentState.isPostalCodeFieldRequired).willReturn(false)
-        given(currentState.currentSelectedCountry).willReturn(
-            SupportedCountriesViewEntity(
-                countryCode = "US",
-                countryName = "USA",
-                isPostalCodeEnabled = false,
-            ),
-        )
-        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "",
-            ),
-        )
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = true,
-                messageText = "",
-            ),
-        )
-
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(true)
+            on { emailInputField }.doReturn(InputFieldState("test@example.com"))
+            on { isBillingCountryFieldRequired }.doReturn(false)
+            on { isPostalCodeFieldRequired }.doReturn(false)
+            on { currentSelectedCountry }.doReturn(
+                SupportedCountriesViewEntity(
+                    countryCode = "US",
+                    countryName = "USA",
+                    isPostalCodeEnabled = false,
+                ),
+            )
+            on { postalCodeField }.doReturn(InputFieldState("12345"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "",
+                ),
+            )
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = true,
+                    messageText = "",
+                ),
+            )
+        }
         // Act
 
         val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
@@ -137,21 +138,22 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with email and billing is disabled then should returns correct payload without email and billing address`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(false)
-        given(currentState.isBillingCountryFieldRequired).willReturn(false)
-        given(currentState.isPostalCodeFieldRequired).willReturn(false)
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = false,
-                messageText = "",
-            ),
-        )
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(false)
+            on { isBillingCountryFieldRequired }.doReturn(false)
+            on { isPostalCodeFieldRequired }.doReturn(false)
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = false,
+                    messageText = "",
+                ),
+            )
+        }
 
         // Act
 
@@ -176,22 +178,22 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with valid month then should returns correct month`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(false)
-        given(currentState.isBillingCountryFieldRequired).willReturn(false)
-        given(currentState.isPostalCodeFieldRequired).willReturn(false)
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = false,
-                messageText = "",
-            ),
-        )
-
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(false)
+            on { isBillingCountryFieldRequired }.doReturn(false)
+            on { isPostalCodeFieldRequired }.doReturn(false)
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = false,
+                    messageText = "",
+                ),
+            )
+        }
         // Act
 
         val expiryMonth =
@@ -204,22 +206,22 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with blank month then should returns empty string`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(false)
-        given(currentState.isBillingCountryFieldRequired).willReturn(false)
-        given(currentState.isPostalCodeFieldRequired).willReturn(false)
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState(""))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = false,
-                messageText = "",
-            ),
-        )
-
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(false)
+            on { isBillingCountryFieldRequired }.doReturn(false)
+            on { isPostalCodeFieldRequired }.doReturn(false)
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState(""))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = false,
+                    messageText = "",
+                ),
+            )
+        }
         // Act
 
         val expiryMonth =
@@ -232,21 +234,22 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with valid year then should returns correct year`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(false)
-        given(currentState.isBillingCountryFieldRequired).willReturn(false)
-        given(currentState.isPostalCodeFieldRequired).willReturn(false)
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = false,
-                messageText = "",
-            ),
-        )
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(false)
+            on { isBillingCountryFieldRequired }.doReturn(false)
+            on { isPostalCodeFieldRequired }.doReturn(false)
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = false,
+                    messageText = "",
+                ),
+            )
+        }
 
         // Act
 
@@ -260,21 +263,22 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with blank year then should returns empty string`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(false)
-        given(currentState.isBillingCountryFieldRequired).willReturn(false)
-        given(currentState.isPostalCodeFieldRequired).willReturn(false)
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState(""))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = false,
-                messageText = "",
-            ),
-        )
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(false)
+            on { isBillingCountryFieldRequired }.doReturn(false)
+            on { isPostalCodeFieldRequired }.doReturn(false)
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState(""))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = false,
+                    messageText = "",
+                ),
+            )
+        }
 
         // Act
 
@@ -288,32 +292,32 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with isStartDestination as true then should returns correct payload with savePaymentMethod as null and mitConsentwhen as checkBox state`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(true)
-        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
-        given(currentState.isBillingCountryFieldRequired).willReturn(true)
-        given(currentState.currentSelectedCountry).willReturn(
-            SupportedCountriesViewEntity(
-                countryCode = "US",
-                countryName = "USA",
-                isPostalCodeEnabled = false,
-            ),
-        )
-        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.isPostalCodeFieldRequired).willReturn(true)
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState(""))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = true,
-                isChecked = true,
-                messageText = "",
-            ),
-        )
-
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(true)
+            on { emailInputField }.doReturn(InputFieldState("test@example.com"))
+            on { isBillingCountryFieldRequired }.doReturn(true)
+            on { currentSelectedCountry }.doReturn(
+                SupportedCountriesViewEntity(
+                    countryCode = "US",
+                    countryName = "USA",
+                    isPostalCodeEnabled = false,
+                ),
+            )
+            on { postalCodeField }.doReturn(InputFieldState("12345"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { isPostalCodeFieldRequired }.doReturn(true)
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState(""))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = true,
+                    isChecked = true,
+                    messageText = "",
+                ),
+            )
+        }
         // Act
 
         val paymentPayload = mapper.getPaymentPayLoad(
@@ -341,30 +345,31 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     @Test
     fun `when calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible then  should returns correct payload with savePaymentMethod as null`() {
         // Arrange
-        val currentState: CardDetailsCheckoutState = mock()
-        given(currentState.isEmailInputFieldRequired).willReturn(true)
-        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
-        given(currentState.isBillingCountryFieldRequired).willReturn(true)
-        given(currentState.currentSelectedCountry).willReturn(
-            SupportedCountriesViewEntity(
-                countryCode = "US",
-                countryName = "USA",
-                isPostalCodeEnabled = false,
-            ),
-        )
-        given(currentState.isPostalCodeFieldRequired).willReturn(true)
-        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
-        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
-        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
-        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
-        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
-        given(currentState.checkBoxItem).willReturn(
-            CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "",
-            ),
-        )
+        val currentState: CardDetailsCheckoutState = mock {
+            on { isEmailInputFieldRequired }.doReturn(true)
+            on { emailInputField }.doReturn(InputFieldState("test@example.com"))
+            on { isBillingCountryFieldRequired }.doReturn(true)
+            on { currentSelectedCountry }.doReturn(
+                SupportedCountriesViewEntity(
+                    countryCode = "US",
+                    countryName = "USA",
+                    isPostalCodeEnabled = false,
+                ),
+            )
+            on { isPostalCodeFieldRequired }.doReturn(true)
+            on { postalCodeField }.doReturn(InputFieldState("12345"))
+            on { cardNumberInputField }.doReturn(InputFieldState("1234567812345678"))
+            on { cardHolderInputField }.doReturn(InputFieldState("John Doe"))
+            on { cardExpireDateInputField }.doReturn(InputFieldState("1225"))
+            on { cvvInputFieldState }.doReturn(InputFieldState("123"))
+            on { checkBoxItem }.doReturn(
+                CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "",
+                ),
+            )
+        }
 
         // Act
 

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -3,8 +3,8 @@ package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
@@ -23,33 +23,33 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with email and billing enabled then should returns correct payload with email and billing address`() {
+    fun `when calling getPaymentPayLoad with email and billing enabled then should returns correct payload with email and billing address`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
-        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(true)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(true)
-        whenever(currentState.currentSelectedCountry).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(true)
+        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
+        given(currentState.isBillingCountryFieldRequired).willReturn(true)
+        given(currentState.isPostalCodeFieldRequired).willReturn(true)
+        given(currentState.currentSelectedCountry).willReturn(
             SupportedCountriesViewEntity(
                 countryCode = "US",
                 countryName = "USA",
                 isPostalCodeEnabled = false,
             ),
         )
-        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = false,
                 isChecked = true,
                 messageText = "",
             ),
         )
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
@@ -77,33 +77,33 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with email enabled and billing is disabled then should returns correct payload with email but without billing address`() {
+    fun `when calling getPaymentPayLoad with email enabled and billing is disabled then should returns correct payload with email but without billing address`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
-        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
-        whenever(currentState.currentSelectedCountry).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(true)
+        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
+        given(currentState.isBillingCountryFieldRequired).willReturn(false)
+        given(currentState.isPostalCodeFieldRequired).willReturn(false)
+        given(currentState.currentSelectedCountry).willReturn(
             SupportedCountriesViewEntity(
                 countryCode = "US",
                 countryName = "USA",
                 isPostalCodeEnabled = false,
             ),
         )
-        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = false,
                 isChecked = true,
                 messageText = "",
             ),
         )
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
@@ -135,17 +135,17 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with email and billing is disabled then should returns correct payload without email and billing address`() {
+    fun `when calling getPaymentPayLoad with email and billing is disabled then should returns correct payload without email and billing address`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(false)
+        given(currentState.isBillingCountryFieldRequired).willReturn(false)
+        given(currentState.isPostalCodeFieldRequired).willReturn(false)
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = false,
@@ -174,17 +174,17 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with valid month then should returns correct month`() {
+    fun `when calling getPaymentPayLoad with valid month then should returns correct month`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(false)
+        given(currentState.isBillingCountryFieldRequired).willReturn(false)
+        given(currentState.isPostalCodeFieldRequired).willReturn(false)
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = false,
@@ -202,17 +202,17 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with blank month then should returns empty string`() {
+    fun `when calling getPaymentPayLoad with blank month then should returns empty string`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState(""))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(false)
+        given(currentState.isBillingCountryFieldRequired).willReturn(false)
+        given(currentState.isPostalCodeFieldRequired).willReturn(false)
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState(""))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = false,
@@ -230,17 +230,17 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with valid year then should returns correct year`() {
+    fun `when calling getPaymentPayLoad with valid year then should returns correct year`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(false)
+        given(currentState.isBillingCountryFieldRequired).willReturn(false)
+        given(currentState.isPostalCodeFieldRequired).willReturn(false)
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = false,
@@ -258,17 +258,17 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with blank year then should returns empty string`() {
+    fun `when calling getPaymentPayLoad with blank year then should returns empty string`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState(""))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(false)
+        given(currentState.isBillingCountryFieldRequired).willReturn(false)
+        given(currentState.isPostalCodeFieldRequired).willReturn(false)
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState(""))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = false,
@@ -286,27 +286,27 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with isStartDestination as true then should returns correct payload with savePaymentMethod as null and mitConsentGiven as checkBox state`() {
+    fun `when calling getPaymentPayLoad with isStartDestination as true then should returns correct payload with savePaymentMethod as null and mitConsentwhen as checkBox state`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
-        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(true)
-        whenever(currentState.currentSelectedCountry).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(true)
+        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
+        given(currentState.isBillingCountryFieldRequired).willReturn(true)
+        given(currentState.currentSelectedCountry).willReturn(
             SupportedCountriesViewEntity(
                 countryCode = "US",
                 countryName = "USA",
                 isPostalCodeEnabled = false,
             ),
         )
-        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(true)
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState(""))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.isPostalCodeFieldRequired).willReturn(true)
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState(""))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
@@ -339,26 +339,26 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible then  should returns correct payload with savePaymentMethod as null`() {
+    fun `when calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible then  should returns correct payload with savePaymentMethod as null`() {
         // Arrange
         val currentState: CardDetailsCheckoutState = mock()
-        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
-        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
-        whenever(currentState.isBillingCountryFieldRequired).thenReturn(true)
-        whenever(currentState.currentSelectedCountry).thenReturn(
+        given(currentState.isEmailInputFieldRequired).willReturn(true)
+        given(currentState.emailInputField).willReturn(InputFieldState("test@example.com"))
+        given(currentState.isBillingCountryFieldRequired).willReturn(true)
+        given(currentState.currentSelectedCountry).willReturn(
             SupportedCountriesViewEntity(
                 countryCode = "US",
                 countryName = "USA",
                 isPostalCodeEnabled = false,
             ),
         )
-        whenever(currentState.isPostalCodeFieldRequired).thenReturn(true)
-        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
-        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
-        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
-        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
-        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
-        whenever(currentState.checkBoxItem).thenReturn(
+        given(currentState.isPostalCodeFieldRequired).willReturn(true)
+        given(currentState.postalCodeField).willReturn(InputFieldState("12345"))
+        given(currentState.cardNumberInputField).willReturn(InputFieldState("1234567812345678"))
+        given(currentState.cardHolderInputField).willReturn(InputFieldState("John Doe"))
+        given(currentState.cardExpireDateInputField).willReturn(InputFieldState("1225"))
+        given(currentState.cvvInputFieldState).willReturn(InputFieldState("123"))
+        given(currentState.checkBoxItem).willReturn(
             CheckBoxItem(
                 isVisible = false,
                 isChecked = true,

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/CardCheckOutFullCardPaymentPayloadMapperTest.kt
@@ -1,37 +1,63 @@
 package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper
 
-import io.mockk.every
-import io.mockk.mockk
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.entities.DojoAddressDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardDetails
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CheckBoxItem
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.InputFieldState
 
 class CardCheckOutFullCardPaymentPayloadMapperTest {
     private val isStartDestination: Boolean = false
+    private lateinit var mapper: CardCheckOutFullCardPaymentPayloadMapper
+
+    @Before
+    fun setUp() {
+        mapper = CardCheckOutFullCardPaymentPayloadMapper()
+    }
 
     @Test
-    fun `given calling getPaymentPayLoad with email and billing enabled should returns correct payload with email and billing address`() {
+    fun `when calling getPaymentPayLoad with email and billing enabled then should returns correct payload with email and billing address`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.isEmailInputFieldRequired } returns true
-        every { currentState.emailInputField.value } returns "test@example.com"
-        every { currentState.isBillingCountryFieldRequired } returns true
-        every { currentState.currentSelectedCountry.countryCode } returns "US"
-        every { currentState.isPostalCodeFieldRequired } returns true
-        every { currentState.postalCodeField.value } returns "12345"
-        every { currentState.checkBoxItem.isChecked } returns true
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
+        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(true)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(true)
+        whenever(currentState.currentSelectedCountry).thenReturn(
+            SupportedCountriesViewEntity(
+                countryCode = "US",
+                countryName = "USA",
+                isPostalCodeEnabled = false,
+            ),
+        )
+        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = false,
+                isChecked = true,
+                messageText = "",
+            ),
+        )
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = true,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
         val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
 
         // Assert
@@ -51,28 +77,42 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with email enabled and billing is disabled should returns correct payload with email but without billing address`() {
+    fun `when calling getPaymentPayLoad with email enabled and billing is disabled then should returns correct payload with email but without billing address`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.isEmailInputFieldRequired } returns true
-        every { currentState.emailInputField.value } returns "test@example.com"
-        every { currentState.isBillingCountryFieldRequired } returns false
-        every { currentState.isPostalCodeFieldRequired } returns false
-        every { currentState.postalCodeField.value } returns "12345"
-        every { currentState.checkBoxItem.isChecked } returns true
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.currentSelectedCountry } returns SupportedCountriesViewEntity(
-            "",
-            "",
-            false,
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
+        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
+        whenever(currentState.currentSelectedCountry).thenReturn(
+            SupportedCountriesViewEntity(
+                countryCode = "US",
+                countryName = "USA",
+                isPostalCodeEnabled = false,
+            ),
         )
-        every { currentState.checkBoxItem.isVisible } returns true
+        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = false,
+                isChecked = true,
+                messageText = "",
+            ),
+        )
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = true,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+
         val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
 
         // Assert
@@ -95,21 +135,26 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with email and billing is disabled should  returns correct payload without email and billing address`() {
+    fun `when calling getPaymentPayLoad with email and billing is disabled then should returns correct payload without email and billing address`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.isEmailInputFieldRequired } returns false
-        every { currentState.isBillingCountryFieldRequired } returns false
-        every { currentState.isPostalCodeFieldRequired } returns false
-        every { currentState.checkBoxItem.isChecked } returns false
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = false,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+
         val paymentPayload = mapper.getPaymentPayLoad(currentState, isStartDestination)
 
         // Assert
@@ -129,112 +174,148 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with valid month should returns correct month`() {
+    fun `when calling getPaymentPayLoad with valid month then should returns correct month`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.isEmailInputFieldRequired } returns false
-        every { currentState.isBillingCountryFieldRequired } returns false
-        every { currentState.isPostalCodeFieldRequired } returns false
-        every { currentState.checkBoxItem.isChecked } returns false
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = false,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryMonth = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
+
+        val expiryMonth =
+            mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
 
         // Assert
         assertEquals("12", expiryMonth)
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with blank month should returns empty string`() {
+    fun `when calling getPaymentPayLoad with blank month then should returns empty string`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.cardExpireDateInputField.value } returns ""
-        every { currentState.isEmailInputFieldRequired } returns false
-        every { currentState.isBillingCountryFieldRequired } returns false
-        every { currentState.isPostalCodeFieldRequired } returns false
-        every { currentState.checkBoxItem.isChecked } returns false
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState(""))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = false,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryMonth = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
+
+        val expiryMonth =
+            mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryMonth
 
         // Assert
         assertEquals("", expiryMonth)
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with valid year should returns correct year`() {
+    fun `when calling getPaymentPayLoad with valid year then should returns correct year`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.isEmailInputFieldRequired } returns false
-        every { currentState.isBillingCountryFieldRequired } returns false
-        every { currentState.isPostalCodeFieldRequired } returns false
-        every { currentState.checkBoxItem.isChecked } returns false
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = false,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryYear = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
+
+        val expiryYear =
+            mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
 
         // Assert
         assertEquals("25", expiryYear)
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with blank year should returns empty string`() {
+    fun `when  calling getPaymentPayLoad with blank year then should returns empty string`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.cardExpireDateInputField.value } returns ""
-        every { currentState.isEmailInputFieldRequired } returns false
-        every { currentState.isBillingCountryFieldRequired } returns false
-        every { currentState.isPostalCodeFieldRequired } returns false
-        every { currentState.checkBoxItem.isChecked } returns false
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(false)
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(false)
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(false)
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState(""))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = false,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
-        val expiryYear = mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
+
+        val expiryYear =
+            mapper.getPaymentPayLoad(currentState, isStartDestination).cardDetails.expiryYear
 
         // Assert
         assertEquals("", expiryYear)
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with isStartDestination as true  should returns correct payload with savePaymentMethod as null and mitConsentGiven as checkBox state`() {
+    fun `when calling getPaymentPayLoad with isStartDestination as true then should returns correct payload with savePaymentMethod as null and mitConsentGiven as checkBox state`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.isEmailInputFieldRequired } returns true
-        every { currentState.emailInputField.value } returns "test@example.com"
-        every { currentState.isBillingCountryFieldRequired } returns true
-        every { currentState.currentSelectedCountry.countryCode } returns "US"
-        every { currentState.isPostalCodeFieldRequired } returns true
-        every { currentState.postalCodeField.value } returns "12345"
-        every { currentState.checkBoxItem.isChecked } returns true
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns true
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
+        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(true)
+        whenever(currentState.currentSelectedCountry).thenReturn(
+            SupportedCountriesViewEntity(
+                countryCode = "US",
+                countryName = "USA",
+                isPostalCodeEnabled = false,
+            ),
+        )
+        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(true)
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState(""))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = true,
+                isChecked = true,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+
         val paymentPayload = mapper.getPaymentPayLoad(
             currentState = currentState,
             isStartDestination = true,
@@ -248,8 +329,8 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
             cardDetails = DojoCardDetails(
                 cardNumber = "1234567812345678",
                 cardName = "John Doe",
-                expiryMonth = "12",
-                expiryYear = "25",
+                expiryMonth = "",
+                expiryYear = "",
                 cv2 = "123",
                 mitConsentGiven = true,
             ),
@@ -258,24 +339,35 @@ class CardCheckOutFullCardPaymentPayloadMapperTest {
     }
 
     @Test
-    fun `given calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible  should returns correct payload with savePaymentMethod as null`() {
+    fun `when calling getPaymentPayLoad with isStartDestination as false and checkBox is inVisible then  should returns correct payload with savePaymentMethod as null`() {
         // Arrange
-        val currentState = mockk<CardDetailsCheckoutState>()
-        every { currentState.isEmailInputFieldRequired } returns true
-        every { currentState.emailInputField.value } returns "test@example.com"
-        every { currentState.isBillingCountryFieldRequired } returns true
-        every { currentState.currentSelectedCountry.countryCode } returns "US"
-        every { currentState.isPostalCodeFieldRequired } returns true
-        every { currentState.postalCodeField.value } returns "12345"
-        every { currentState.checkBoxItem.isChecked } returns true
-        every { currentState.cardNumberInputField.value } returns "1234567812345678"
-        every { currentState.cardHolderInputField.value } returns "John Doe"
-        every { currentState.cardExpireDateInputField.value } returns "1225"
-        every { currentState.cvvInputFieldState.value } returns "123"
-        every { currentState.checkBoxItem.isVisible } returns false
+        val currentState: CardDetailsCheckoutState = mock()
+        whenever(currentState.isEmailInputFieldRequired).thenReturn(true)
+        whenever(currentState.emailInputField).thenReturn(InputFieldState("test@example.com"))
+        whenever(currentState.isBillingCountryFieldRequired).thenReturn(true)
+        whenever(currentState.currentSelectedCountry).thenReturn(
+            SupportedCountriesViewEntity(
+                countryCode = "US",
+                countryName = "USA",
+                isPostalCodeEnabled = false,
+            ),
+        )
+        whenever(currentState.isPostalCodeFieldRequired).thenReturn(true)
+        whenever(currentState.postalCodeField).thenReturn(InputFieldState("12345"))
+        whenever(currentState.cardNumberInputField).thenReturn(InputFieldState("1234567812345678"))
+        whenever(currentState.cardHolderInputField).thenReturn(InputFieldState("John Doe"))
+        whenever(currentState.cardExpireDateInputField).thenReturn(InputFieldState("1225"))
+        whenever(currentState.cvvInputFieldState).thenReturn(InputFieldState("123"))
+        whenever(currentState.checkBoxItem).thenReturn(
+            CheckBoxItem(
+                isVisible = false,
+                isChecked = true,
+                messageText = "",
+            ),
+        )
 
         // Act
-        val mapper = CardCheckOutFullCardPaymentPayloadMapper()
+
         val paymentPayload = mapper.getPaymentPayLoad(
             currentState = currentState,
             isStartDestination = false,

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -408,7 +408,12 @@ class CardDetailsCheckoutViewModelTest {
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
             supportedCountriesViewEntity,
         )
-        whenever(cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(any())).thenReturn(
+        whenever(
+            cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(
+                any(),
+                isStartDestination,
+            ),
+        ).thenReturn(
             fullCardPaymentPayload,
         )
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,6 +38,7 @@ import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetails
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CheckBoxItem
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.InputFieldState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.validator.CardCheckoutScreenValidator
+
 @Suppress("LongMethod", "LargeClass")
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
@@ -56,8 +58,22 @@ class CardDetailsCheckoutViewModelTest {
     private val allowedPaymentMethodsViewEntityMapper: AllowedPaymentMethodsViewEntityMapper =
         mock()
     private val cardCheckoutScreenValidator: CardCheckoutScreenValidator = mock()
-    private val cardCheckOutFullCardPaymentPayloadMapper: CardCheckOutFullCardPaymentPayloadMapper = mock()
+    private val cardCheckOutFullCardPaymentPayloadMapper: CardCheckOutFullCardPaymentPayloadMapper =
+        mock()
     private val stringProvider: StringProvider = mock()
+    private val isStartDestination: Boolean = false
+
+    @Before
+    fun setUp() {
+        val toolBarTitle = "toolBarTitle"
+        val payTitle = "pay"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)).thenReturn(
+            toolBarTitle,
+        )
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn(
+            payTitle,
+        )
+    }
 
     @Test
     fun `test initial state`() = runTest {
@@ -66,9 +82,9 @@ class CardDetailsCheckoutViewModelTest {
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
-        val messageText = "messageText"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+
         val expected = CardDetailsCheckoutState(
+            toolbarTitle = "toolBarTitle",
             totalAmount = "",
             amountCurrency = "",
             allowedPaymentMethodsIcons = emptyList(),
@@ -82,8 +98,8 @@ class CardDetailsCheckoutViewModelTest {
             isEmailInputFieldRequired = false,
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = true,
-                messageText = messageText,
+                isChecked = false,
+                messageText = "",
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
@@ -102,6 +118,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -131,16 +148,20 @@ class CardDetailsCheckoutViewModelTest {
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
-        val messageText = "messageText"
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
+
         val expected = CardDetailsCheckoutState(
+            orderId = "", merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = false,
             supportedCountriesList = emptyList(),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "", countryCode = "", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "",
+                countryCode = "",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = ""),
@@ -152,7 +173,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             postalCodeField = InputFieldState(value = ""),
             actionButtonState = ActionButtonState(text = payText),
@@ -169,6 +190,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -208,19 +230,25 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
 
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
-        val messageText = "messageText"
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         val expected = CardDetailsCheckoutState(
+            toolbarTitle = "toolBarTitle",
+            orderId = "",
+            merchantName = "",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = ""),
@@ -232,7 +260,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             postalCodeField = InputFieldState(value = ""),
             actionButtonState = ActionButtonState(text = payText),
@@ -249,6 +277,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -289,18 +318,24 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        val messageText = "messageText"
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
+            orderId = "",
+            merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = ""),
@@ -312,7 +347,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
-                messageText = messageText,
+                messageText = "",
             ),
             postalCodeField = InputFieldState(value = ""),
             actionButtonState = ActionButtonState(text = payText),
@@ -329,6 +364,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -369,19 +405,27 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        whenever(cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(any())).thenReturn(fullCardPaymentPayload)
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
+        whenever(cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(any())).thenReturn(
+            fullCardPaymentPayload,
+        )
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
-        val messageText = "messageText"
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         val expected = CardDetailsCheckoutState(
+            orderId = "",
+            merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = ""),
@@ -392,7 +436,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -410,6 +454,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         viewModel.onPayWithCardClicked()
         // assert
@@ -452,18 +497,24 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        val messageText = "messageText"
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
+            orderId = "",
+            merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = ""),
@@ -474,7 +525,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -492,6 +543,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         viewModel.onPayWithCardClicked()
         paymentStateFakeFlow.tryEmit(false)
@@ -548,18 +600,24 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        val messageText = "messageText"
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
+            orderId = "",
+            merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = "new"),
             emailInputField = InputFieldState(value = ""),
@@ -570,7 +628,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -588,6 +646,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
 
         viewModel.onCardHolderValueChanged("new")
@@ -629,18 +688,24 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        val messageText = "messageText"
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
+            orderId = "",
+            merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = ""),
@@ -651,7 +716,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -669,6 +734,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         viewModel.onCardNumberValueChanged("new")
         viewModel.onCvvValueChanged("new")
@@ -712,18 +778,24 @@ class CardDetailsCheckoutViewModelTest {
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        val messageText = "messageText"
+        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            supportedCountriesViewEntity,
+        )
         val payText = "pay £ 100"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
+            orderId = "",
+            merchantName = "",
+            toolbarTitle = "toolBarTitle",
             totalAmount = "100",
             amountCurrency = "£",
             isBillingCountryFieldRequired = true,
             supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(countryName = "EGP", countryCode = "EG", isPostalCodeEnabled = true),
+            currentSelectedCountry = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            ),
             allowedPaymentMethodsIcons = listOf(1, 2, 3),
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = "new"),
@@ -731,7 +803,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = messageText,
+                messageText = "",
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
@@ -753,6 +825,7 @@ class CardDetailsCheckoutViewModelTest {
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
             stringProvider,
+            isStartDestination,
         )
         viewModel.onEmailValueChanged("new")
         // assert
@@ -760,66 +833,69 @@ class CardDetailsCheckoutViewModelTest {
     }
 
     @Test
-    fun `pay button should be disabled if any of cardCheckoutScreenValidator methods return false `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        whenever(cardCheckoutScreenValidator.isCardNumberValid(any())).thenReturn(false)
-        whenever(cardCheckoutScreenValidator.isCvvValid(any())).thenReturn(false)
-        whenever(cardCheckoutScreenValidator.isCardExpireDateValid(any())).thenReturn(false)
-        whenever(cardCheckoutScreenValidator.isEmailValid(any())).thenReturn(false)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
+    fun `pay button should be disabled if any of cardCheckoutScreenValidator methods return false `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            whenever(cardCheckoutScreenValidator.isCardNumberValid(any())).thenReturn(false)
+            whenever(cardCheckoutScreenValidator.isCvvValid(any())).thenReturn(false)
+            whenever(cardCheckoutScreenValidator.isCardExpireDateValid(any())).thenReturn(false)
+            whenever(cardCheckoutScreenValidator.isEmailValid(any())).thenReturn(false)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
+                countryName = "EGP",
+                countryCode = "EG",
+                isPostalCodeEnabled = true,
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        collectionEmailRequired = true,
                     ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    collectionEmailRequired = true,
                 ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-        val messageText = "messageText"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-        )
-        viewModel.validateCvv("new", false)
-        viewModel.validateCardNumber("new")
-        viewModel.validateEmailValue("new", false)
-        viewModel.validateExpireDate("new", false)
-        // assert
-        Assert.assertEquals(false, viewModel.state.value?.actionButtonState?.isEnabled)
-    }
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+                listOf(
+                    SupportedCountriesDomainEntity("", "", false),
+                ),
+            )
+            whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+                supportedCountriesViewEntity,
+            )
+            whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+            )
+            viewModel.validateCvv("new", false)
+            viewModel.validateCardNumber("new")
+            viewModel.validateEmailValue("new", false)
+            viewModel.validateExpireDate("new", false)
+            // assert
+            Assert.assertEquals(false, viewModel.state.value?.actionButtonState?.isEnabled)
+        }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -13,8 +13,8 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
+import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
@@ -68,13 +68,13 @@ class CardDetailsCheckoutViewModelTest {
         val toolBarTitle = "toolBarTitle"
         val payTitle = "pay"
         val checkBoxMessage = "checkBoxMessage"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn(
+        given(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).willReturn(
             payTitle,
         )
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_save_card_title)).thenReturn(
+        given(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)).willReturn(
             toolBarTitle,
         )
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(
+        given(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).willReturn(
             checkBoxMessage,
         )
     }
@@ -83,9 +83,9 @@ class CardDetailsCheckoutViewModelTest {
     fun `test initial state`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
 
         val expected = CardDetailsCheckoutState(
             toolbarTitle = "toolBarTitle",
@@ -132,10 +132,10 @@ class CardDetailsCheckoutViewModelTest {
     fun `test state when paymentIntent emits with collect billing address false`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -151,7 +151,7 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val payText = "pay £ 100"
 
         val expected = CardDetailsCheckoutState(
@@ -204,7 +204,7 @@ class CardDetailsCheckoutViewModelTest {
     fun `test state when paymentIntent emits with collect billing address true`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -212,7 +212,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -229,16 +229,16 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
 
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val payText = "pay £ 100"
         val expected = CardDetailsCheckoutState(
             toolbarTitle = "toolBarTitle",
@@ -291,7 +291,7 @@ class CardDetailsCheckoutViewModelTest {
     fun `test state when paymentIntent emits with collect userId`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -299,7 +299,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -317,16 +317,16 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
         val payText = "pay £ 100"
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             orderId = "",
             merchantName = "",
@@ -379,7 +379,7 @@ class CardDetailsCheckoutViewModelTest {
         // arrange
         val fullCardPaymentPayload: DojoCardPaymentPayLoad.FullCardPaymentPayload = mockk()
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -387,7 +387,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -404,23 +404,23 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
-        whenever(
+        given(
             cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(
                 any(),
                 any(),
             ),
-        ).thenReturn(
+        ).willReturn(
             fullCardPaymentPayload,
         )
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val payText = "pay £ 100"
         val expected = CardDetailsCheckoutState(
             orderId = "",
@@ -476,7 +476,7 @@ class CardDetailsCheckoutViewModelTest {
     fun `test loading state when paymentState emits after clicking on pay `() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -484,7 +484,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -501,16 +501,16 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
         val payText = "pay £ 100"
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             orderId = "",
             merchantName = "",
@@ -564,22 +564,22 @@ class CardDetailsCheckoutViewModelTest {
     fun `test state when user update card holder field `() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
-        whenever(cardCheckoutScreenValidator.isCardNumberValid(any())).thenReturn(true)
-        whenever(cardCheckoutScreenValidator.isCvvValid(any())).thenReturn(true)
-        whenever(cardCheckoutScreenValidator.isCardExpireDateValid(any())).thenReturn(true)
-        whenever(
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+        given(cardCheckoutScreenValidator.isCardNumberValid(any())).willReturn(true)
+        given(cardCheckoutScreenValidator.isCvvValid(any())).willReturn(true)
+        given(cardCheckoutScreenValidator.isCardExpireDateValid(any())).willReturn(true)
+        given(
             cardCheckoutScreenValidator.isEmailFieldValidWithInputFieldVisibility(
                 any(),
                 any(),
             ),
-        ).thenReturn(true)
-        whenever(
+        ).willReturn(true)
+        given(
             cardCheckoutScreenValidator.isPostalCodeFieldWithInputFieldVisibility(
                 any(),
                 any(),
             ),
-        ).thenReturn(true)
+        ).willReturn(true)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -587,7 +587,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -604,16 +604,16 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
         val payText = "pay £ 100"
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             orderId = "",
             merchantName = "",
@@ -667,7 +667,7 @@ class CardDetailsCheckoutViewModelTest {
     fun `test state when user update card information field `() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -675,7 +675,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -692,16 +692,16 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
         val payText = "pay £ 100"
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             orderId = "",
             merchantName = "",
@@ -756,7 +756,7 @@ class CardDetailsCheckoutViewModelTest {
     fun `test state when user update email address  field `() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         val supportedCountriesViewEntity = SupportedCountriesViewEntity(
             countryName = "EGP",
@@ -764,7 +764,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeEnabled = true,
         )
         val supportedIcons = listOf(1, 2, 3)
-        whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
         paymentIntentFakeFlow.tryEmit(
             PaymentIntentResult.Success(
                 result = PaymentIntentDomainEntity(
@@ -782,16 +782,16 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         paymentStateFakeFlow.tryEmit(true)
-        whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
             listOf(
                 SupportedCountriesDomainEntity("", "", false),
             ),
         )
-        whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
             supportedCountriesViewEntity,
         )
         val payText = "pay £ 100"
-        whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             orderId = "",
             merchantName = "",
@@ -847,19 +847,19 @@ class CardDetailsCheckoutViewModelTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(null)
-            whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
             val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-            whenever(cardCheckoutScreenValidator.isCardNumberValid(any())).thenReturn(false)
-            whenever(cardCheckoutScreenValidator.isCvvValid(any())).thenReturn(false)
-            whenever(cardCheckoutScreenValidator.isCardExpireDateValid(any())).thenReturn(false)
-            whenever(cardCheckoutScreenValidator.isEmailValid(any())).thenReturn(false)
+            given(cardCheckoutScreenValidator.isCardNumberValid(any())).willReturn(false)
+            given(cardCheckoutScreenValidator.isCvvValid(any())).willReturn(false)
+            given(cardCheckoutScreenValidator.isCardExpireDateValid(any())).willReturn(false)
+            given(cardCheckoutScreenValidator.isEmailValid(any())).willReturn(false)
             val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
             )
             val supportedIcons = listOf(1, 2, 3)
-            whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
             paymentIntentFakeFlow.tryEmit(
                 PaymentIntentResult.Success(
                     result = PaymentIntentDomainEntity(
@@ -877,15 +877,15 @@ class CardDetailsCheckoutViewModelTest {
                 ),
             )
             paymentStateFakeFlow.tryEmit(true)
-            whenever(getSupportedCountriesUseCase.getSupportedCountries()).thenReturn(
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
                 listOf(
                     SupportedCountriesDomainEntity("", "", false),
                 ),
             )
-            whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(
+            given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
                 supportedCountriesViewEntity,
             )
-            whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
             // act
             val viewModel = CardDetailsCheckoutViewModel(
                 observePaymentIntent,

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -10,10 +10,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito.verify
 import org.mockito.junit.MockitoJUnitRunner
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
@@ -67,11 +67,15 @@ class CardDetailsCheckoutViewModelTest {
     fun setUp() {
         val toolBarTitle = "toolBarTitle"
         val payTitle = "pay"
-        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)).thenReturn(
-            toolBarTitle,
-        )
+        val checkBoxMessage = "checkBoxMessage"
         whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn(
             payTitle,
+        )
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_save_card_title)).thenReturn(
+            toolBarTitle,
+        )
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(
+            checkBoxMessage,
         )
     }
 
@@ -98,7 +102,7 @@ class CardDetailsCheckoutViewModelTest {
             isEmailInputFieldRequired = false,
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
+                isChecked = true,
                 messageText = "",
             ),
             cardNumberInputField = InputFieldState(value = ""),
@@ -172,8 +176,8 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeFieldRequired = false,
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             postalCodeField = InputFieldState(value = ""),
             actionButtonState = ActionButtonState(text = payText),
@@ -259,8 +263,8 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeFieldRequired = true,
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             postalCodeField = InputFieldState(value = ""),
             actionButtonState = ActionButtonState(text = payText),
@@ -284,7 +288,7 @@ class CardDetailsCheckoutViewModelTest {
     }
 
     @Test
-    fun `test state when paymentIntent emits with collect userId  `() = runTest {
+    fun `test state when paymentIntent emits with collect userId`() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
@@ -347,7 +351,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
-                messageText = "",
+                messageText = "checkBoxMessage",
             ),
             postalCodeField = InputFieldState(value = ""),
             actionButtonState = ActionButtonState(text = payText),
@@ -411,7 +415,7 @@ class CardDetailsCheckoutViewModelTest {
         whenever(
             cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(
                 any(),
-                isStartDestination,
+                any(),
             ),
         ).thenReturn(
             fullCardPaymentPayload,
@@ -440,8 +444,8 @@ class CardDetailsCheckoutViewModelTest {
             cvvInputFieldState = InputFieldState(value = ""),
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -529,8 +533,8 @@ class CardDetailsCheckoutViewModelTest {
             cvvInputFieldState = InputFieldState(value = ""),
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -632,12 +636,12 @@ class CardDetailsCheckoutViewModelTest {
             cvvInputFieldState = InputFieldState(value = ""),
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(isEnabled = true, text = payText),
+            actionButtonState = ActionButtonState(isEnabled = false, text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -720,8 +724,8 @@ class CardDetailsCheckoutViewModelTest {
             cvvInputFieldState = InputFieldState(value = "new"),
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
@@ -807,8 +811,8 @@ class CardDetailsCheckoutViewModelTest {
             isEmailInputFieldRequired = true,
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
-                isChecked = false,
-                messageText = "",
+                isChecked = true,
+                messageText = "checkBoxMessage",
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -28,6 +28,7 @@ import tech.dojo.pay.uisdk.domain.entities.SupportedCountriesDomainEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.SupportedCountriesViewEntityMapper
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.ActionButtonState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CheckBoxItem
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.InputFieldState
@@ -79,8 +80,7 @@ class CardDetailsCheckoutViewModelTest {
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
+            actionButtonState = ActionButtonState(),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -141,8 +141,7 @@ class CardDetailsCheckoutViewModelTest {
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
+            actionButtonState = ActionButtonState(),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -216,9 +215,7 @@ class CardDetailsCheckoutViewModelTest {
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
-
+            actionButtonState = ActionButtonState(),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -293,9 +290,7 @@ class CardDetailsCheckoutViewModelTest {
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
             ),
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
-
+            actionButtonState = ActionButtonState(),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -369,8 +364,7 @@ class CardDetailsCheckoutViewModelTest {
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            isLoading = true,
-            isEnabled = false,
+            actionButtonState = ActionButtonState(isLoading = true),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -447,8 +441,7 @@ class CardDetailsCheckoutViewModelTest {
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
+            actionButtonState = ActionButtonState(),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -539,8 +532,7 @@ class CardDetailsCheckoutViewModelTest {
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = true,
+            actionButtonState = ActionButtonState(isEnabled = true),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -616,8 +608,7 @@ class CardDetailsCheckoutViewModelTest {
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
+            actionButtonState = ActionButtonState(),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -695,8 +686,7 @@ class CardDetailsCheckoutViewModelTest {
             cvvInputFieldState = InputFieldState(value = ""),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            isLoading = false,
-            isEnabled = false,
+            actionButtonState = ActionButtonState(),
 
         )
         // act
@@ -773,6 +763,6 @@ class CardDetailsCheckoutViewModelTest {
         viewModel.validateEmailValue("new", false)
         viewModel.validateExpireDate("new", false)
         // assert
-        Assert.assertEquals(false, viewModel.state.value?.isEnabled)
+        Assert.assertEquals(false, viewModel.state.value?.actionButtonState?.isEnabled)
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -72,7 +72,7 @@ class CardDetailsCheckoutViewModelTest {
             isPostalCodeFieldRequired = false,
             postalCodeField = InputFieldState(value = ""),
             isEmailInputFieldRequired = false,
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = true,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -135,7 +135,7 @@ class CardDetailsCheckoutViewModelTest {
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
             isPostalCodeFieldRequired = false,
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -209,7 +209,7 @@ class CardDetailsCheckoutViewModelTest {
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
             isPostalCodeFieldRequired = true,
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -284,7 +284,7 @@ class CardDetailsCheckoutViewModelTest {
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
             isPostalCodeFieldRequired = true,
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -357,7 +357,7 @@ class CardDetailsCheckoutViewModelTest {
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -434,7 +434,7 @@ class CardDetailsCheckoutViewModelTest {
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -525,7 +525,7 @@ class CardDetailsCheckoutViewModelTest {
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -601,7 +601,7 @@ class CardDetailsCheckoutViewModelTest {
             cardNumberInputField = InputFieldState(value = "new"),
             cardExpireDateInputField = InputFieldState(value = "new"),
             cvvInputFieldState = InputFieldState(value = "new"),
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
@@ -676,7 +676,7 @@ class CardDetailsCheckoutViewModelTest {
             cardHolderInputField = InputFieldState(value = ""),
             emailInputField = InputFieldState(value = "new"),
             isEmailInputFieldRequired = true,
-            saveCardCheckBox = CheckBoxItem(
+            checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
                 messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -1,6 +1,7 @@
 package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -14,6 +15,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
+import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.core.MainCoroutineScopeRule
@@ -27,6 +29,7 @@ import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.SupportedCountriesDomainEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.CardCheckOutFullCardPaymentPayloadMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.SupportedCountriesViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.ActionButtonState
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
@@ -52,6 +55,7 @@ class CardDetailsCheckoutViewModelTest {
     private val allowedPaymentMethodsViewEntityMapper: AllowedPaymentMethodsViewEntityMapper =
         mock()
     private val cardCheckoutScreenValidator: CardCheckoutScreenValidator = mock()
+    private val cardCheckOutFullCardPaymentPayloadMapper: CardCheckOutFullCardPaymentPayloadMapper = mock()
 
     @Test
     fun `test initial state`() = runTest {
@@ -92,6 +96,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -153,6 +158,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -227,6 +233,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -302,6 +309,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -310,6 +318,7 @@ class CardDetailsCheckoutViewModelTest {
     @Test
     fun `test state when user clicks on pay button with normal card payment`() = runTest {
         // arrange
+        val fullCardPaymentPayload: DojoCardPaymentPayLoad.FullCardPaymentPayload = mockk()
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
@@ -342,7 +351,7 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        whenever(cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(any())).thenReturn(fullCardPaymentPayload)
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
@@ -376,6 +385,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         viewModel.onPayWithCardClicked()
         // assert
@@ -453,6 +463,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         viewModel.onPayWithCardClicked()
         paymentStateFakeFlow.tryEmit(false)
@@ -544,6 +555,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
 
         viewModel.onCardHolderValueChanged("new")
@@ -620,6 +632,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         viewModel.onCardNumberValueChanged("new")
         viewModel.onCvvValueChanged("new")
@@ -699,6 +712,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         viewModel.onEmailValueChanged("new")
         // assert
@@ -757,6 +771,7 @@ class CardDetailsCheckoutViewModelTest {
             supportedCountriesViewEntityMapper,
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
+            cardCheckOutFullCardPaymentPayloadMapper,
         )
         viewModel.validateCvv("new", false)
         viewModel.validateCardNumber("new")

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -19,6 +19,7 @@ import tech.dojo.pay.sdk.card.entities.DojoCardPaymentPayLoad
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.core.MainCoroutineScopeRule
+import tech.dojo.pay.uisdk.core.StringProvider
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentResult
 import tech.dojo.pay.uisdk.domain.GetSupportedCountriesUseCase
 import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
@@ -56,6 +57,7 @@ class CardDetailsCheckoutViewModelTest {
         mock()
     private val cardCheckoutScreenValidator: CardCheckoutScreenValidator = mock()
     private val cardCheckOutFullCardPaymentPayloadMapper: CardCheckOutFullCardPaymentPayloadMapper = mock()
+    private val stringProvider: StringProvider = mock()
 
     @Test
     fun `test initial state`() = runTest {
@@ -64,6 +66,8 @@ class CardDetailsCheckoutViewModelTest {
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
         val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
         whenever(observePaymentStatus.observePaymentStates()).thenReturn(paymentStateFakeFlow)
+        val messageText = "messageText"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
         val expected = CardDetailsCheckoutState(
             totalAmount = "",
             amountCurrency = "",
@@ -79,7 +83,7 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = true,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
@@ -97,6 +101,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -126,6 +131,10 @@ class CardDetailsCheckoutViewModelTest {
         )
         paymentStateFakeFlow.tryEmit(true)
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
             amountCurrency = "£",
@@ -143,10 +152,10 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
+            actionButtonState = ActionButtonState(text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -159,6 +168,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -201,6 +211,10 @@ class CardDetailsCheckoutViewModelTest {
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
 
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
             amountCurrency = "£",
@@ -218,10 +232,10 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
+            actionButtonState = ActionButtonState(text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -234,6 +248,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -275,7 +290,10 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
@@ -294,10 +312,10 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = true,
                 isChecked = true,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
+            actionButtonState = ActionButtonState(text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -310,6 +328,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         // assert
         Assert.assertEquals(expected, viewModel.state.value)
@@ -353,6 +372,10 @@ class CardDetailsCheckoutViewModelTest {
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
         whenever(cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(any())).thenReturn(fullCardPaymentPayload)
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
             amountCurrency = "£",
@@ -369,11 +392,11 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(isLoading = true),
+            actionButtonState = ActionButtonState(isLoading = true, text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -386,6 +409,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         viewModel.onPayWithCardClicked()
         // assert
@@ -429,7 +453,10 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
@@ -447,11 +474,11 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
+            actionButtonState = ActionButtonState(text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -464,6 +491,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         viewModel.onPayWithCardClicked()
         paymentStateFakeFlow.tryEmit(false)
@@ -521,7 +549,10 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
@@ -539,11 +570,11 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(isEnabled = true),
+            actionButtonState = ActionButtonState(isEnabled = true, text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -556,6 +587,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
 
         viewModel.onCardHolderValueChanged("new")
@@ -598,7 +630,10 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
@@ -616,11 +651,11 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
+            actionButtonState = ActionButtonState(text = payText),
         )
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -633,6 +668,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         viewModel.onCardNumberValueChanged("new")
         viewModel.onCvvValueChanged("new")
@@ -677,7 +713,10 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        val messageText = "messageText"
+        val payText = "pay £ 100"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_button_pay)).thenReturn("pay")
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         val expected = CardDetailsCheckoutState(
             totalAmount = "100",
@@ -692,14 +731,14 @@ class CardDetailsCheckoutViewModelTest {
             checkBoxItem = CheckBoxItem(
                 isVisible = false,
                 isChecked = false,
-                messageText = R.string.dojo_ui_sdk_card_details_checkout_save_card,
+                messageText = messageText,
             ),
             cardNumberInputField = InputFieldState(value = ""),
             cardExpireDateInputField = InputFieldState(value = ""),
             cvvInputFieldState = InputFieldState(value = ""),
             isPostalCodeFieldRequired = true,
             postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
+            actionButtonState = ActionButtonState(text = payText),
 
         )
         // act
@@ -713,6 +752,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         viewModel.onEmailValueChanged("new")
         // assert
@@ -720,7 +760,7 @@ class CardDetailsCheckoutViewModelTest {
     }
 
     @Test
-    fun `pay button should be disabled  if  any of cardCheckoutScreenValidator methods return false `() = runTest {
+    fun `pay button should be disabled if any of cardCheckoutScreenValidator methods return false `() = runTest {
         // arrange
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
         whenever(observePaymentIntent.observePaymentIntent()).thenReturn(paymentIntentFakeFlow)
@@ -759,7 +799,8 @@ class CardDetailsCheckoutViewModelTest {
             ),
         )
         whenever(supportedCountriesViewEntityMapper.apply(any())).thenReturn(supportedCountriesViewEntity)
-
+        val messageText = "messageText"
+        whenever(stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_save_card)).thenReturn(messageText)
         whenever(allowedPaymentMethodsViewEntityMapper.apply(any())).thenReturn(supportedIcons)
         // act
         val viewModel = CardDetailsCheckoutViewModel(
@@ -772,6 +813,7 @@ class CardDetailsCheckoutViewModelTest {
             allowedPaymentMethodsViewEntityMapper,
             cardCheckoutScreenValidator,
             cardCheckOutFullCardPaymentPayloadMapper,
+            stringProvider,
         )
         viewModel.validateCvv("new", false)
         viewModel.validateCardNumber("new")


### PR DESCRIPTION
## what 
- make UI SDK supports card  on file payment  without refreshing the setup intent 
- do some cleanup on the `CardDetailsCheckoutViewModel` and also update the view state to make it supports both payment types normal payment and set up payment 
- update needs unit tests 
- update the sample app to support the new payments 
## screenshots 

https://github.com/dojo-engineering/android-dojo-pay-sdk/assets/71371440/72c9f9d0-1722-4464-a4c6-56ce9399633c

