### PR TITLE
Feature/pppp 157 if set up intent is collected navigate to result screen

### DIFF
--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
@@ -20,6 +20,7 @@ internal data class PaymentIntentDomainEntity(
     val collectionShippingAddressRequired: Boolean = false,
     val isSetUpIntentPayment: Boolean = false,
     val merchantName: String = "",
+    val isPaymentAlreadyCollected: Boolean = false,
 )
 
 data class AmountDomainEntity(
@@ -32,3 +33,20 @@ internal data class ItemLinesDomainEntity(
     val caption: String,
     val amount: Amount,
 )
+
+internal enum class PaymentIntentStatusDomainEntity(val status: String) {
+    CREATED("Created"),
+    AUTHORIZED("Authorized"),
+    CAPTURED("Captured"),
+    REVERSED("Reversed"),
+    REFUNDED("Refunded"),
+    CANCELED("Canceled"),
+    NOT_SUPPORTED(""),
+    ;
+
+    companion object {
+        fun fromStatus(status: String): PaymentIntentStatusDomainEntity =
+            PaymentIntentStatusDomainEntity.values()
+                .find { it.status == status } ?: NOT_SUPPORTED
+    }
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
@@ -6,6 +6,7 @@ import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.EssentialParamMissingException
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.PaymentIntentStatusDomainEntity
 
 internal class PaymentIntentDomainEntityMapper {
     fun apply(raw: PaymentIntentPayload): PaymentIntentDomainEntity {
@@ -38,6 +39,9 @@ internal class PaymentIntentDomainEntityMapper {
             orderId = raw.reference ?: "",
             isSetUpIntentPayment = !raw.merchantInitiatedType.isNullOrBlank() && !raw.paymentSource.isNullOrBlank(),
             merchantName = raw.config?.tradingName ?: "",
+            isPaymentAlreadyCollected =
+            PaymentIntentStatusDomainEntity.fromStatus(requireNotNull(raw.status)) == PaymentIntentStatusDomainEntity.CAPTURED ||
+                PaymentIntentStatusDomainEntity.fromStatus(requireNotNull(raw.status)) == PaymentIntentStatusDomainEntity.AUTHORIZED,
         )
     }
 
@@ -49,6 +53,7 @@ internal class PaymentIntentDomainEntityMapper {
         if (raw.merchantConfig == null) invalidParams.add("merchantConfig")
         if (raw.merchantConfig?.supportedPaymentMethods == null) invalidParams.add("supportedPaymentMethods")
         if (raw.merchantConfig?.supportedPaymentMethods?.cardSchemes == null) invalidParams.add("cardSchemes")
+        if (raw.status == null) invalidParams.add("status")
         if (invalidParams.isNotEmpty()) throw EssentialParamMissingException(invalidParams)
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -75,14 +75,18 @@ internal class PaymentFlowViewModel(
             paymentType,
         )
         if (isInitCorrectly) {
-            currentCustomerId = paymentIntentResult.result.customerId
-            if (paymentType == DojoPaymentType.PAYMENT_CARD) {
-                fetchPaymentMethodsUseCase.fetchPaymentMethodsWithPaymentType(
-                    paymentType,
-                    paymentIntentResult.result.customerId ?: "",
-                    customerSecret,
+            if (paymentIntentResult.result.isPaymentAlreadyCollected) {
+                navigateToPaymentResult(DojoPaymentResult.SUCCESSFUL)
+            } else {
+                currentCustomerId = paymentIntentResult.result.customerId
+                if (paymentType == DojoPaymentType.PAYMENT_CARD) {
+                    fetchPaymentMethodsUseCase.fetchPaymentMethodsWithPaymentType(
+                        paymentType,
+                        paymentIntentResult.result.customerId ?: "",
+                        customerSecret,
 
-                )
+                    )
+                }
             }
         } else {
             closeFlowWithInternalError()

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModel.kt
@@ -84,7 +84,6 @@ internal class PaymentFlowViewModel(
                         paymentType,
                         paymentIntentResult.result.customerId ?: "",
                         customerSecret,
-
                     )
                 }
             }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/BasicCardNumberInPutField.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/BasicCardNumberInPutField.kt
@@ -117,7 +117,7 @@ internal fun BasicCardNumberInputField(
         unfocusedBorderColor = DojoTheme.colors.inputFieldDefaultBorderColor,
         backgroundColor = DojoTheme.colors.inputFieldBackgroundColor,
         focusedBorderColor = DojoTheme.colors.inputFieldSelectedBorderColor,
-        placeholderColor = DojoTheme.colors.inputFieldPlaceholderColor,
+        placeholderColor = DojoTheme.colors.inputFieldPlaceholderColor.copy(alpha = 0.5f),
         errorBorderColor = DojoTheme.colors.errorTextColor,
         errorCursorColor = DojoTheme.colors.errorTextColor,
         errorLabelColor = DojoTheme.colors.errorTextColor,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/BasicCardNumberInPutField.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/BasicCardNumberInPutField.kt
@@ -117,7 +117,7 @@ internal fun BasicCardNumberInputField(
         unfocusedBorderColor = DojoTheme.colors.inputFieldDefaultBorderColor,
         backgroundColor = DojoTheme.colors.inputFieldBackgroundColor,
         focusedBorderColor = DojoTheme.colors.inputFieldSelectedBorderColor,
-        placeholderColor = DojoTheme.colors.inputFieldPlaceholderColor.copy(alpha = 0.5f),
+        placeholderColor = DojoTheme.colors.inputFieldPlaceholderColor,
         errorBorderColor = DojoTheme.colors.errorTextColor,
         errorCursorColor = DojoTheme.colors.errorTextColor,
         errorLabelColor = DojoTheme.colors.errorTextColor,

--- a/uisdk/src/main/res/values/strings.xml
+++ b/uisdk/src/main/res/values/strings.xml
@@ -76,5 +76,5 @@
     <string name = "dojo_ui_sdk_payment_result_title_setup_intent_success">Card saved</string>
     <string name = "dojo_ui_sdk_payment_result_title_setup_intent_fail">Card was not saved</string>
     <string name = "dojo_ui_sdk_payment_result_main_title_setup_intent_success">Card saved successfully</string>
-    <string name = "dojo_ui_sdk_payment_result_main_title_setup_intent_fail">Failed to save card details</string>
+    <string name = "dojo_ui_sdk_payment_result_main_title_setup_intent_fail">we could not save your card details</string>
 </resources>

--- a/uisdk/src/main/res/values/strings.xml
+++ b/uisdk/src/main/res/values/strings.xml
@@ -76,5 +76,5 @@
     <string name = "dojo_ui_sdk_payment_result_title_setup_intent_success">Card saved</string>
     <string name = "dojo_ui_sdk_payment_result_title_setup_intent_fail">Card was not saved</string>
     <string name = "dojo_ui_sdk_payment_result_main_title_setup_intent_success">Card saved successfully</string>
-    <string name = "dojo_ui_sdk_payment_result_main_title_setup_intent_fail">we could not save your card details</string>
+    <string name = "dojo_ui_sdk_payment_result_main_title_setup_intent_fail">We could not save your card details</string>
 </resources>

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -42,6 +42,30 @@ internal class PaymentIntentDomainEntityMapperTest {
         }
 
     @Test
+    fun `when calling apply with valid PaymentIntentPayload with status as captured then should map to PaymentIntentDomainEntity with isPaymentAlreadyCollected as true `() =
+        runTest {
+            // arrange
+            val raw = createValidPaymentIntentPayload().copy(status = "Captured")
+            val expected = getValidPaymentIntentDomainEntity().copy(isPaymentAlreadyCollected = true)
+            // act
+            val actual = PaymentIntentDomainEntityMapper().apply(raw)
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
+
+    @Test
+    fun `when calling apply with valid PaymentIntentPayload with status as authorized then should map to PaymentIntentDomainEntity with isPaymentAlreadyCollected as true `() =
+        runTest {
+            // arrange
+            val raw = createValidPaymentIntentPayload().copy(status = "Authorized")
+            val expected = getValidPaymentIntentDomainEntity().copy(isPaymentAlreadyCollected = true)
+            // act
+            val actual = PaymentIntentDomainEntityMapper().apply(raw)
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
+
+    @Test
     fun `when calling apply with invalid PaymentIntentPayload should Thrown EssentialParamMissingException that contains all the missing fields`() =
         runTest {
             // arrange

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.junit.MockitoJUnitRunner
@@ -29,6 +30,13 @@ import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
 internal class PaymentIntentDomainEntityMapperTest {
+    private lateinit var mapper: PaymentIntentDomainEntityMapper
+
+    @Before
+    fun setUp() {
+        mapper = PaymentIntentDomainEntityMapper()
+    }
+
     @Test
     fun `when calling apply with valid PaymentIntentPayload then should map to PaymentIntentDomainEntity with all valid data`() =
         runTest {
@@ -36,31 +44,31 @@ internal class PaymentIntentDomainEntityMapperTest {
             val raw = createValidPaymentIntentPayload()
             val expected = getValidPaymentIntentDomainEntity()
             // act
-            val actual = PaymentIntentDomainEntityMapper().apply(raw)
+            val actual = mapper.apply(raw)
             // assert
             Assert.assertEquals(expected, actual)
         }
 
     @Test
-    fun `when calling apply with valid PaymentIntentPayload with status as captured then should map to PaymentIntentDomainEntity with isPaymentAlreadyCollected as true `() =
+    fun `when calling apply with valid PaymentIntentPayload with status as captured then should map to PaymentIntentDomainEntity with isPaymentAlreadyCollected as true`() =
         runTest {
             // arrange
             val raw = createValidPaymentIntentPayload().copy(status = "Captured")
             val expected = getValidPaymentIntentDomainEntity().copy(isPaymentAlreadyCollected = true)
             // act
-            val actual = PaymentIntentDomainEntityMapper().apply(raw)
+            val actual = mapper.apply(raw)
             // assert
             Assert.assertEquals(expected, actual)
         }
 
     @Test
-    fun `when calling apply with valid PaymentIntentPayload with status as authorized then should map to PaymentIntentDomainEntity with isPaymentAlreadyCollected as true `() =
+    fun `when calling apply with valid PaymentIntentPayload with status as authorized then should map to PaymentIntentDomainEntity with isPaymentAlreadyCollected as true`() =
         runTest {
             // arrange
             val raw = createValidPaymentIntentPayload().copy(status = "Authorized")
             val expected = getValidPaymentIntentDomainEntity().copy(isPaymentAlreadyCollected = true)
             // act
-            val actual = PaymentIntentDomainEntityMapper().apply(raw)
+            val actual = mapper.apply(raw)
             // assert
             Assert.assertEquals(expected, actual)
         }
@@ -73,7 +81,7 @@ internal class PaymentIntentDomainEntityMapperTest {
             // act
             val actual = assertThrows(
                 EssentialParamMissingException::class.java,
-            ) { PaymentIntentDomainEntityMapper().apply(raw) }
+            ) { mapper.apply(raw) }
             // assert
             assertTrue(actual.message?.contains("clientSessionSecret") ?: false)
             assertTrue(actual.message?.contains("amount") ?: false)

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -482,7 +482,7 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `when call isPaymentInSandBoxEnvironment with prod paymentID should return false `() =
+    fun `when call isPaymentInSandBoxEnvironment with prod paymentID should return false`() =
         runTest {
             // arrange
             val viewModel = PaymentFlowViewModel(

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/PaymentFlowViewModelTest.kt
@@ -52,13 +52,18 @@ internal class PaymentFlowViewModelTest {
     private val isSDKInitializedCorrectlyUseCase: IsSDKInitializedCorrectlyUseCase = mock()
 
     @Test
-    fun `when initialize view model with Success state from payment intent then should call fetch payment methods `() =
+    fun `when initialize view model with Success state from payment intent and isPaymentAlreadyCollected is false and  isSDKInitializedCorrectlyUseCase return true  then should call fetch payment methods `() =
         runTest {
             // arrange
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             // act
             PaymentFlowViewModel(
                 paymentId,
@@ -76,6 +81,43 @@ internal class PaymentFlowViewModelTest {
                 "customerId",
                 customerSecret,
             )
+        }
+
+    @Test
+    fun `when initialize view model with Success state from payment intent with isPaymentAlreadyCollected as true then navigation should emits PaymentResult`() =
+        runTest {
+            // arrange
+            val expected =
+                PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(
+                    successPaymentIntent().copy(
+                        result = successPaymentIntent().result.copy(
+                            isPaymentAlreadyCollected = true,
+                        ),
+                    ),
+                )
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+                isSDKInitializedCorrectlyUseCase,
+            )
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
         }
 
     @Test
@@ -112,7 +154,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(false)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(false)
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -136,7 +183,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -160,7 +212,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             // act
             val viewModel = PaymentFlowViewModel(
                 paymentId,
@@ -183,7 +240,9 @@ internal class PaymentFlowViewModelTest {
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
             MutableStateFlow(successPaymentIntent())
         given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(
+            true,
+        )
         val expected = PaymentFlowNavigationEvents.OnBack
         // act
         val viewModel = PaymentFlowViewModel(
@@ -209,7 +268,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             val expected =
                 PaymentFlowNavigationEvents.PaymentMethodsCheckOutWithSelectedPaymentMethod()
             // act
@@ -235,7 +299,9 @@ internal class PaymentFlowViewModelTest {
         val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
             MutableStateFlow(successPaymentIntent())
         given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(
+            true,
+        )
         val expected = PaymentFlowNavigationEvents.OnCloseFlow
         // act
         val viewModel = PaymentFlowViewModel(
@@ -261,7 +327,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             val expected =
                 PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.SUCCESSFUL, true)
             // act
@@ -288,7 +359,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             val expected = PaymentFlowNavigationEvents.PaymentResult(
                 DojoPaymentResult.SDK_INTERNAL_ERROR,
                 false,
@@ -317,7 +393,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             val expected =
                 PaymentFlowNavigationEvents.PaymentResult(DojoPaymentResult.FAILED, false)
             // act
@@ -338,30 +419,36 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `when calling navigateToCardDetailsCheckoutScreen should emits CardDetailsCheckout`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
-            MutableStateFlow(successPaymentIntent())
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
-        val expected = PaymentFlowNavigationEvents.CardDetailsCheckout
-        // act
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-            isSDKInitializedCorrectlyUseCase,
-        )
+    fun `when calling navigateToCardDetailsCheckoutScreen should emits CardDetailsCheckout`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(successPaymentIntent())
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
+            val expected = PaymentFlowNavigationEvents.CardDetailsCheckout
+            // act
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+                isSDKInitializedCorrectlyUseCase,
+            )
 
-        viewModel.navigateToCardDetailsCheckoutScreen()
-        val actual = viewModel.navigationEvent.value
-        // assert
-        Assert.assertEquals(expected, actual)
-    }
+            viewModel.navigateToCardDetailsCheckoutScreen()
+            val actual = viewModel.navigationEvent.value
+            // assert
+            Assert.assertEquals(expected, actual)
+        }
 
     @Test
     fun `when calling navigateToManagePaymentMethods should emits ManagePaymentMethods with customer id `() =
@@ -370,7 +457,12 @@ internal class PaymentFlowViewModelTest {
             val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
                 MutableStateFlow(successPaymentIntent())
             given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-            given(isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(any(), any())).willReturn(true)
+            given(
+                isSDKInitializedCorrectlyUseCase.isSDKInitiatedCorrectly(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
             val expected = PaymentFlowNavigationEvents.ManagePaymentMethods("customerId")
             // act
             val viewModel = PaymentFlowViewModel(
@@ -390,23 +482,24 @@ internal class PaymentFlowViewModelTest {
         }
 
     @Test
-    fun `when call isPaymentInSandBoxEnvironment with prod paymentID should return false `() = runTest {
-        // arrange
-        val viewModel = PaymentFlowViewModel(
-            paymentId,
-            customerSecret,
-            paymentType,
-            fetchPaymentIntentUseCase,
-            observePaymentIntent,
-            fetchPaymentMethodsUseCase,
-            updatePaymentStateUseCase,
-            isSDKInitializedCorrectlyUseCase,
-        )
-        // act
-        val actual = viewModel.isPaymentInSandBoxEnvironment()
-        // assert
-        Assert.assertFalse(actual)
-    }
+    fun `when call isPaymentInSandBoxEnvironment with prod paymentID should return false `() =
+        runTest {
+            // arrange
+            val viewModel = PaymentFlowViewModel(
+                paymentId,
+                customerSecret,
+                paymentType,
+                fetchPaymentIntentUseCase,
+                observePaymentIntent,
+                fetchPaymentMethodsUseCase,
+                updatePaymentStateUseCase,
+                isSDKInitializedCorrectlyUseCase,
+            )
+            // act
+            val actual = viewModel.isPaymentInSandBoxEnvironment()
+            // assert
+            Assert.assertFalse(actual)
+        }
 
     @Test
     fun `when call isPaymentInSandBoxEnvironment with sankBox paymentID should return true `() =


### PR DESCRIPTION
## what 
- handle the case of having a payment status as `Captured` or `Authorized` to navigate directly to the result screen with success state 
## screen shots 

https://github.com/dojo-engineering/android-dojo-pay-sdk/assets/71371440/ac2cff8a-ee73-40c9-978d-f943760c41de


https://github.com/dojo-engineering/android-dojo-pay-sdk/assets/71371440/e375b0be-a66b-4b63-a9cb-25d7c1f35fd1

