### PR TITLE
Bump cardinal sdk to 2.2.7-4

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -41,7 +41,7 @@ object Versions {
     const val RETROFIT= "2.9.0"
     const val GPAY= "19.1.0"
     const val JSON_TEST= "20180813"
-    const val CARDINAL= "2.2.7-3"
+    const val CARDINAL= "2.2.7-4"
     const val MOCKK="1.13.4"
 }
 


### PR DESCRIPTION
A new version of Cardinal SDK is now available , 
https://cardinaldocs.atlassian.net/wiki/spaces/-- CMSDK/pages/3101523969/Cardinal+Mobile+SDK+2.2.7-4+Android