### PR TITLE
Feature/pppp 182 populate data for email/address fields from payment intent if the data is present

### DIFF
--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/data/entities/PaymentIntentPayload.kt
@@ -6,6 +6,8 @@ import tech.dojo.pay.sdk.card.entities.WalletSchemes
 internal data class PaymentIntentPayload(
     val id: String? = null,
     val captureMode: String? = null,
+    val billingAddress: BillingAddress? = null,
+    val shippingDetails: ShippingDetails? = null,
     val transactionSource: String? = null,
     val clientSessionSecret: String? = null,
     val clientSessionSecretExpirationDate: String? = null,
@@ -31,38 +33,38 @@ internal data class PaymentIntentPayload(
 )
 
 internal data class ItemLines(
-    val caption: String,
-    val amountTotal: Amount,
+    val caption: String?,
+    val amountTotal: Amount?,
 )
 
 internal data class Amount(
-    val value: Long,
-    val currencyCode: String,
+    val value: Long?,
+    val currencyCode: String?,
 )
 
 internal data class Config(
-    val tradingName: String,
-    val branding: Branding,
-    val customerEmail: CustomerEmail,
-    val billingAddress: BillingAddress,
-    val shippingDetails: ShippingAddress,
+    val tradingName: String?,
+    val branding: Branding?,
+    val customerEmail: CollectCustomerEmail?,
+    val billingAddress: CollectBillingAddress?,
+    val shippingDetails: CollectShippingAddress?,
 )
 
-internal data class CustomerEmail(
-    val collectionRequired: Boolean,
+internal data class CollectCustomerEmail(
+    val collectionRequired: Boolean?,
 )
 
-data class BillingAddress(
-    val collectionRequired: Boolean,
+data class CollectBillingAddress(
+    val collectionRequired: Boolean?,
 )
 
-data class ShippingAddress(
-    val collectionRequired: Boolean,
+data class CollectShippingAddress(
+    val collectionRequired: Boolean?,
 )
 
 internal data class Branding(
-    val logoURL: String,
-    val faviconURL: String,
+    val logoURL: String?,
+    val faviconURL: String?,
 )
 
 internal data class MerchantConfig(
@@ -74,6 +76,20 @@ internal data class SupportedPaymentMethods(
     val wallets: List<WalletSchemes>? = null,
 )
 
-data class Metadata(val locationID: String)
+data class Metadata(val locationID: String?)
 
-data class Customer(val id: String)
+data class Customer(
+    val id: String?,
+    val emailAddress: String?,
+)
+
+data class BillingAddress(
+    val postcode: String?,
+    val countryCode: String,
+    val city: String?,
+)
+
+data class ShippingDetails(
+    val name: String?,
+    val deliveryNotes: String?,
+)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
@@ -2,7 +2,6 @@ package tech.dojo.pay.uisdk.domain.entities
 
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
 import tech.dojo.pay.sdk.card.entities.WalletSchemes
-import tech.dojo.pay.uisdk.data.entities.Amount
 
 internal data class PaymentIntentDomainEntity(
     val id: String,
@@ -31,7 +30,12 @@ data class AmountDomainEntity(
 
 internal data class ItemLinesDomainEntity(
     val caption: String,
-    val amount: Amount,
+    val amount: ItemLinesAmountDomainEntity,
+)
+
+internal data class ItemLinesAmountDomainEntity(
+    val value: Long,
+    val currencyCode: String,
 )
 
 internal enum class PaymentIntentStatusDomainEntity(val status: String) {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/PaymentIntentDomainEntity.kt
@@ -11,6 +11,7 @@ internal data class PaymentIntentDomainEntity(
     val supportedWalletSchemes: List<WalletSchemes> = emptyList(),
     val itemLines: List<ItemLinesDomainEntity>? = null,
     val customerId: String? = null,
+    val customerEmailAddress: String? = null,
     val collectionEmailRequired: Boolean = false,
     val isVirtualTerminalPayment: Boolean = false,
     val collectionBillingAddressRequired: Boolean = false,
@@ -20,6 +21,8 @@ internal data class PaymentIntentDomainEntity(
     val isSetUpIntentPayment: Boolean = false,
     val merchantName: String = "",
     val isPaymentAlreadyCollected: Boolean = false,
+    val billingAddress: BillingAddressDomainEntity? = null,
+    val shippingDetails: ShippingDetailsDomainEntity? = null,
 )
 
 data class AmountDomainEntity(
@@ -54,3 +57,14 @@ internal enum class PaymentIntentStatusDomainEntity(val status: String) {
                 .find { it.status == status } ?: NOT_SUPPORTED
     }
 }
+
+data class BillingAddressDomainEntity(
+    val postcode: String?,
+    val countryCode: String?,
+    val city: String?,
+)
+
+data class ShippingDetailsDomainEntity(
+    val name: String?,
+    val deliveryNotes: String?,
+)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/SupportedCountriesDomainEntity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/entities/SupportedCountriesDomainEntity.kt
@@ -3,14 +3,15 @@ package tech.dojo.pay.uisdk.domain.entities
 internal data class SupportedCountriesDomainEntity(
     val countryName: String,
     val countryCode: String,
-    val isPostalCodeEnabled: Boolean
+    val isPostalCodeEnabled: Boolean,
 )
 
 internal enum class PostalCodeSupportedCountries(val countryCode: String) {
     UK("GB"),
     USA("US"),
     CANADA("CA"),
-    NOT_SUPPORTED("");
+    NOT_SUPPORTED(""),
+    ;
 
     companion object {
         fun fromCountryCode(countryCode: String): PostalCodeSupportedCountries =

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
@@ -3,6 +3,7 @@ package tech.dojo.pay.uisdk.domain.mapper
 import tech.dojo.pay.sdk.card.presentation.gpay.util.centsToString
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentPayload
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.ItemLinesAmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentStatusDomainEntity
@@ -62,8 +63,11 @@ internal class PaymentIntentDomainEntityMapper {
             supportedWalletSchemes = raw.merchantConfig?.supportedPaymentMethods?.wallets.orEmpty(),
             itemLines = raw.itemLines?.map {
                 ItemLinesDomainEntity(
-                    amount = it.amountTotal,
-                    caption = it.caption,
+                    amount = ItemLinesAmountDomainEntity(
+                        value = it.amountTotal?.value ?: 0L,
+                        currencyCode = it.amountTotal?.currencyCode.orEmpty(),
+                    ),
+                    caption = it.caption.orEmpty(),
                 )
             },
             collectionEmailRequired = raw.config?.customerEmail?.collectionRequired ?: false,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapper.kt
@@ -3,10 +3,12 @@ package tech.dojo.pay.uisdk.domain.mapper
 import tech.dojo.pay.sdk.card.presentation.gpay.util.centsToString
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentPayload
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.BillingAddressDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesAmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentStatusDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.ShippingDetailsDomainEntity
 import java.util.Currency
 
 @Suppress("SwallowedException")
@@ -83,5 +85,15 @@ internal class PaymentIntentDomainEntityMapper {
             isPaymentAlreadyCollected =
             PaymentIntentStatusDomainEntity.fromStatus(raw.status.orEmpty())
                 .let { it == PaymentIntentStatusDomainEntity.CAPTURED || it == PaymentIntentStatusDomainEntity.AUTHORIZED },
+            customerEmailAddress = raw.customer?.emailAddress,
+            billingAddress = BillingAddressDomainEntity(
+                postcode = raw.billingAddress?.postcode,
+                countryCode = raw.billingAddress?.countryCode,
+                city = raw.billingAddress?.city,
+            ),
+            shippingDetails = ShippingDetailsDomainEntity(
+                name = raw.shippingDetails?.name,
+                deliveryNotes = raw.shippingDetails?.deliveryNotes,
+            ),
         )
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/SupportedCountriesViewEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/SupportedCountriesViewEntityMapper.kt
@@ -4,11 +4,26 @@ import tech.dojo.pay.uisdk.domain.entities.SupportedCountriesDomainEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 
 internal class SupportedCountriesViewEntityMapper {
+
+    fun mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+        supportedCountriesDomainEntityList: List<SupportedCountriesDomainEntity>,
+        preSelectedCountryCode: String?,
+    ): List<SupportedCountriesViewEntity> {
+        val preSelectedCountryIndex =
+            supportedCountriesDomainEntityList.indexOfFirst { it.countryCode == preSelectedCountryCode }
+        val mutableSupportedCountriesDomainEntityList = supportedCountriesDomainEntityList.toMutableList()
+        if (preSelectedCountryIndex != -1) {
+            val preSelectedCountry = mutableSupportedCountriesDomainEntityList.removeAt(preSelectedCountryIndex)
+            mutableSupportedCountriesDomainEntityList.add(0, preSelectedCountry)
+        }
+        return mutableSupportedCountriesDomainEntityList.map { apply(it) }
+    }
+
     fun apply(domainEntity: SupportedCountriesDomainEntity): SupportedCountriesViewEntity {
         return SupportedCountriesViewEntity(
             countryName = domainEntity.countryName,
             countryCode = domainEntity.countryCode,
-            isPostalCodeEnabled = domainEntity.isPostalCodeEnabled
+            isPostalCodeEnabled = domainEntity.isPostalCodeEnabled,
         )
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -304,9 +304,12 @@ internal class CardDetailsCheckoutViewModel(
     private fun handlePaymentIntent(paymentIntentResult: PaymentIntentResult) {
         if (paymentIntentResult is PaymentIntentResult.Success) {
             val countryList =
-                getSupportedCountriesList(paymentIntentResult.result.collectionBillingAddressRequired)
+                getSupportedCountriesList(
+                    paymentIntentResult.result.collectionBillingAddressRequired,
+                    paymentIntentResult.result.billingAddress?.countryCode,
+                )
             val currentSelectedCountry = if (countryList.isNotEmpty()) {
-                getSupportedCountriesList(paymentIntentResult.result.collectionBillingAddressRequired)[0]
+                countryList[0]
             } else {
                 SupportedCountriesViewEntity("", "", true)
             }
@@ -342,12 +345,14 @@ internal class CardDetailsCheckoutViewModel(
         isBillingCountryFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
         supportedCountriesList = countryList,
         currentSelectedCountry = currentSelectedCountry,
-        isPostalCodeFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
+        isPostalCodeFieldRequired = currentSelectedCountry.isPostalCodeEnabled,
         actionButtonState = currentState.actionButtonState.updateText(
             newValue = getActionButtonTitle(
                 paymentIntentResult,
             ),
         ),
+        emailInputField = InputFieldState(value = paymentIntentResult.result.customerEmailAddress ?: ""),
+        postalCodeField = InputFieldState(value = paymentIntentResult.result.billingAddress?.postcode ?: ""),
     )
 
     private fun getHeaderType() = if (isStartDestination) {
@@ -387,11 +392,16 @@ internal class CardDetailsCheckoutViewModel(
             )
         }
 
-    private fun getSupportedCountriesList(collectionBillingAddressRequired: Boolean): List<SupportedCountriesViewEntity> {
+    private fun getSupportedCountriesList(
+        collectionBillingAddressRequired: Boolean,
+        selectedCountryCode: String?,
+    ): List<SupportedCountriesViewEntity> {
         return if (collectionBillingAddressRequired) {
-            getSupportedCountriesUseCase
-                .getSupportedCountries()
-                .map { supportedCountriesViewEntityMapper.apply(it) }
+            supportedCountriesViewEntityMapper
+                .mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    getSupportedCountriesUseCase.getSupportedCountries(),
+                    selectedCountryCode,
+                )
         } else {
             emptyList()
         }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -345,7 +345,7 @@ internal class CardDetailsCheckoutViewModel(
         isBillingCountryFieldRequired = paymentIntentResult.result.collectionBillingAddressRequired,
         supportedCountriesList = countryList,
         currentSelectedCountry = currentSelectedCountry,
-        isPostalCodeFieldRequired = currentSelectedCountry.isPostalCodeEnabled,
+        isPostalCodeFieldRequired = applyIsPostalCodeFieldRequiredLogic(currentSelectedCountry, paymentIntentResult.result.collectionBillingAddressRequired),
         actionButtonState = currentState.actionButtonState.updateText(
             newValue = getActionButtonTitle(
                 paymentIntentResult,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -436,13 +436,10 @@ internal class CardDetailsCheckoutViewModel(
                 .getUpdatedPaymentTokenFlow()
                 .collectLatest {
                     when (it) {
-                        is RefreshPaymentIntentResult.Success -> {
+                        is RefreshPaymentIntentResult.Success ->
                             executeCardPayment(paymentToken = it.token)
-                        }
-
                         is RefreshPaymentIntentResult.RefreshFailure ->
                             navigateToCardResult(DojoPaymentResult.SDK_INTERNAL_ERROR)
-
                         null -> Unit
                     }
                 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -11,17 +11,18 @@ import org.mockito.junit.MockitoJUnitRunner
 import tech.dojo.pay.sdk.card.entities.CardsSchemes
 import tech.dojo.pay.sdk.card.entities.WalletSchemes
 import tech.dojo.pay.uisdk.data.entities.Amount
-import tech.dojo.pay.uisdk.data.entities.BillingAddress
 import tech.dojo.pay.uisdk.data.entities.Branding
+import tech.dojo.pay.uisdk.data.entities.CollectBillingAddress
+import tech.dojo.pay.uisdk.data.entities.CollectCustomerEmail
+import tech.dojo.pay.uisdk.data.entities.CollectShippingAddress
 import tech.dojo.pay.uisdk.data.entities.Config
 import tech.dojo.pay.uisdk.data.entities.Customer
-import tech.dojo.pay.uisdk.data.entities.CustomerEmail
 import tech.dojo.pay.uisdk.data.entities.ItemLines
 import tech.dojo.pay.uisdk.data.entities.MerchantConfig
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentPayload
-import tech.dojo.pay.uisdk.data.entities.ShippingAddress
 import tech.dojo.pay.uisdk.data.entities.SupportedPaymentMethods
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.ItemLinesAmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 
@@ -110,7 +111,7 @@ internal class PaymentIntentDomainEntityMapperTest {
             10L,
             "GBP",
         ),
-        customer = Customer(id = "id"),
+        customer = Customer(id = "id", emailAddress = "emailAddress"),
         reference = "reference",
         merchantConfig = MerchantConfig(
             supportedPaymentMethods = SupportedPaymentMethods(
@@ -121,9 +122,9 @@ internal class PaymentIntentDomainEntityMapperTest {
         config = Config(
             tradingName = "tradingName",
             branding = Branding(logoURL = "logoURL", faviconURL = "faviconURL"),
-            customerEmail = CustomerEmail(true),
-            billingAddress = BillingAddress(true),
-            shippingDetails = ShippingAddress(true),
+            customerEmail = CollectCustomerEmail(true),
+            billingAddress = CollectBillingAddress(true),
+            shippingDetails = CollectShippingAddress(true),
         ),
         merchantInitiatedType = "merchantInitiatedType",
         itemLines = listOf(
@@ -139,7 +140,7 @@ internal class PaymentIntentDomainEntityMapperTest {
     )
 
     private fun getValidPaymentIntentDomainEntity(): PaymentIntentDomainEntity {
-        val amountItem = Amount(
+        val amountItem = ItemLinesAmountDomainEntity(
             10L,
             "GBP",
         )

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/domain/mapper/PaymentIntentDomainEntityMapperTest.kt
@@ -22,9 +22,11 @@ import tech.dojo.pay.uisdk.data.entities.MerchantConfig
 import tech.dojo.pay.uisdk.data.entities.PaymentIntentPayload
 import tech.dojo.pay.uisdk.data.entities.SupportedPaymentMethods
 import tech.dojo.pay.uisdk.domain.entities.AmountDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.BillingAddressDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesAmountDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.ItemLinesDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
+import tech.dojo.pay.uisdk.domain.entities.ShippingDetailsDomainEntity
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(MockitoJUnitRunner::class)
@@ -159,7 +161,9 @@ internal class PaymentIntentDomainEntityMapperTest {
         val collectionShippingAddressRequired = true
         val isSetUpIntentPayment = true
         val merchantName = "tradingName"
-
+        val customerEmailAddress = "emailAddress"
+        val billingAddress = BillingAddressDomainEntity(postcode = null, countryCode = null, city = null)
+        val shippingDetails = ShippingDetailsDomainEntity(name = null, deliveryNotes = null)
         return PaymentIntentDomainEntity(
             id = id,
             paymentToken = clientSessionSecret,
@@ -176,6 +180,9 @@ internal class PaymentIntentDomainEntityMapperTest {
             collectionShippingAddressRequired = collectionShippingAddressRequired,
             isSetUpIntentPayment = isSetUpIntentPayment,
             merchantName = merchantName,
+            customerEmailAddress = customerEmailAddress,
+            billingAddress = billingAddress,
+            shippingDetails = shippingDetails,
         )
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/SupportedCountriesViewEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/mapper/SupportedCountriesViewEntityMapperTest.kt
@@ -1,0 +1,145 @@
+package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import tech.dojo.pay.uisdk.domain.entities.SupportedCountriesDomainEntity
+import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
+
+class SupportedCountriesViewEntityMapperTest {
+
+    private lateinit var mapper: SupportedCountriesViewEntityMapper
+
+    @Before
+    fun setUp() {
+        mapper = SupportedCountriesViewEntityMapper()
+    }
+
+    @Test
+    fun `when calling mapToSupportedCountriesViewEntityWithPreSelectedCountry with preSelectedCountryCode contained in the list should move preSelectedCountry to the beginning`() {
+        // Arrange
+        val preSelectedCountryCode = "US"
+        val countryList = listOf(
+            SupportedCountriesDomainEntity(
+                countryName = "Canada",
+                countryCode = "CA",
+                isPostalCodeEnabled = false,
+            ),
+            SupportedCountriesDomainEntity(
+                countryName = "United Kingdom",
+                countryCode = "UK",
+                isPostalCodeEnabled = true,
+            ),
+            SupportedCountriesDomainEntity(
+                countryName = "United States",
+                countryCode = "US",
+                isPostalCodeEnabled = true,
+            ),
+        )
+        val expected = listOf(
+            SupportedCountriesViewEntity(
+                countryName = "United States",
+                countryCode = "US",
+                isPostalCodeEnabled = true,
+            ),
+            SupportedCountriesViewEntity(
+                countryName = "Canada",
+                countryCode = "CA",
+                isPostalCodeEnabled = false,
+            ),
+            SupportedCountriesViewEntity(
+                countryName = "United Kingdom",
+                countryCode = "UK",
+                isPostalCodeEnabled = true,
+            ),
+        )
+
+        // Act
+        val actual = mapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+            countryList,
+            preSelectedCountryCode,
+        )
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when calling mapToSupportedCountriesViewEntityWithPreSelectedCountry with preSelectedCountryCode not contained in the list should not change order if preSelectedCountry is not in the list`() {
+        // Arrange
+        val preSelectedCountryCode = "AU"
+        val countryList = listOf(
+            SupportedCountriesDomainEntity(
+                countryName = "Canada",
+                countryCode = "CA",
+                isPostalCodeEnabled = false,
+            ),
+            SupportedCountriesDomainEntity(
+                countryName = "United Kingdom",
+                countryCode = "UK",
+                isPostalCodeEnabled = true,
+            ),
+            SupportedCountriesDomainEntity(
+                countryName = "United States",
+                countryCode = "US",
+                isPostalCodeEnabled = true,
+            ),
+        )
+
+        val expected = listOf(
+            SupportedCountriesViewEntity(
+                countryName = "Canada",
+                countryCode = "CA",
+                isPostalCodeEnabled = false,
+            ),
+            SupportedCountriesViewEntity(
+                countryName = "United Kingdom",
+                countryCode = "UK",
+                isPostalCodeEnabled = true,
+            ),
+            SupportedCountriesViewEntity(
+                countryName = "United States",
+                countryCode = "US",
+                isPostalCodeEnabled = true,
+            ),
+        )
+        // Act
+        val actual = mapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+            countryList,
+            preSelectedCountryCode,
+        )
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when calling mapToSupportedCountriesViewEntityWithPreSelectedCountry with empty list should return empty lost `() {
+        // Arrange
+        val preSelectedCountryCode = "US"
+        val countryList = emptyList<SupportedCountriesDomainEntity>()
+
+        // Act
+        val result = mapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+            countryList,
+            preSelectedCountryCode,
+        )
+
+        // Assert
+        assertEquals(emptyList<SupportedCountriesViewEntity>(), result)
+    }
+
+    @Test
+    fun `when calling apply should map SupportedCountriesDomainEntity to SupportedCountriesViewEntity`() {
+        // Arrange
+        val domainEntity = SupportedCountriesDomainEntity("US", "United States", true)
+
+        // Act
+        val result = mapper.apply(domainEntity)
+
+        // Assert
+        assertEquals(domainEntity.countryCode, result.countryCode)
+        assertEquals(domainEntity.countryName, result.countryName)
+        assertEquals(domainEntity.isPostalCodeEnabled, result.isPostalCodeEnabled)
+    }
+}

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -249,7 +249,7 @@ class CardDetailsCheckoutViewModelTest {
                 cardNumberInputField = InputFieldState(value = ""),
                 cardExpireDateInputField = InputFieldState(value = ""),
                 cvvInputFieldState = InputFieldState(value = ""),
-                isPostalCodeFieldRequired = true,
+                isPostalCodeFieldRequired = false,
                 checkBoxItem = CheckBoxItem(
                     isVisible = false,
                     isChecked = true,

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -92,830 +92,878 @@ class CardDetailsCheckoutViewModelTest {
     }
 
     @Test
-    fun `when init viewModel with isStartDestination as false should emit correct state`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+    fun `when init viewModel with isStartDestination as false should emit correct state`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
 
-        val expected = CardDetailsCheckoutState(
-            isLoading = false,
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "",
-            amountCurrency = "",
-            allowedPaymentMethodsIcons = emptyList(),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isBillingCountryFieldRequired = false,
-            supportedCountriesList = emptyList(),
-            currentSelectedCountry = SupportedCountriesViewEntity("", "", false),
-            isPostalCodeFieldRequired = false,
-            postalCodeField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "",
-            ),
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
-
-    @Test
-    fun `when init viewModel with isStartDestination as true should emit correct state with full loading as true  and correct toolBar title `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        isStartDestination = true
-
-        val expected = CardDetailsCheckoutState(
-            isLoading = true,
-            toolbarTitle = "saveCardToolBar",
-            totalAmount = "",
-            amountCurrency = "",
-            allowedPaymentMethodsIcons = emptyList(),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isBillingCountryFieldRequired = false,
-            supportedCountriesList = emptyList(),
-            currentSelectedCountry = SupportedCountriesViewEntity("", "", false),
-            isPostalCodeFieldRequired = false,
-            postalCodeField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = false,
-                messageText = "",
-            ),
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
-
-    @Test
-    fun `when payment intent flow collect with collect billing address false viewModel should emit state without billing country `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+            val expected = CardDetailsCheckoutState(
+                isLoading = false,
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "",
+                amountCurrency = "",
+                allowedPaymentMethodsIcons = emptyList(),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isBillingCountryFieldRequired = false,
+                supportedCountriesList = emptyList(),
+                currentSelectedCountry = SupportedCountriesViewEntity("", "", false),
+                isPostalCodeFieldRequired = false,
+                postalCodeField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "",
                 ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val payText = "pay £ 100"
-
-        val expected = CardDetailsCheckoutState(
-            orderId = "", merchantName = "",
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = false,
-            supportedCountriesList = emptyList(),
-            currentSelectedCountry = SupportedCountriesViewEntity(
-                countryName = "",
-                countryCode = "",
-                isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            isPostalCodeFieldRequired = false,
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(text = payText),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
-    fun `when payment intent flow collect with collect billing address true viewModel should emit state with  billing country `() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
+    fun `when init viewModel with isStartDestination as true should emit correct state with full loading as true  and correct toolBar title `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            isStartDestination = true
 
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val payText = "pay £ 100"
-        val expected = CardDetailsCheckoutState(
-            toolbarTitle = "toolBarTitle",
-            orderId = "",
-            merchantName = "",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = true,
-            supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(
+            val expected = CardDetailsCheckoutState(
+                isLoading = true,
+                toolbarTitle = "saveCardToolBar",
+                totalAmount = "",
+                amountCurrency = "",
+                allowedPaymentMethodsIcons = emptyList(),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isBillingCountryFieldRequired = false,
+                supportedCountriesList = emptyList(),
+                currentSelectedCountry = SupportedCountriesViewEntity("", "", false),
+                isPostalCodeFieldRequired = false,
+                postalCodeField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = false,
+                    messageText = "",
+                ),
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
+
+    @Test
+    fun `when payment intent flow collect with collect billing address false viewModel should emit state without billing country `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedIcons = listOf(1, 2, 3)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val payText = "pay £ 100"
+
+            val expected = CardDetailsCheckoutState(
+                orderId = "", merchantName = "",
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = false,
+                supportedCountriesList = emptyList(),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "",
+                    countryCode = "",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                isPostalCodeFieldRequired = true,
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(text = payText),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
+
+    @Test
+    fun `when payment intent flow collect with collect billing address true viewModel should emit state with  billing country `() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            isPostalCodeFieldRequired = true,
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(text = payText),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            val supportedCountriesDomainEntityList = listOf(
+                SupportedCountriesDomainEntity("", "", false),
+            )
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                supportedCountriesDomainEntityList,
+            )
+            given(
+                supportedCountriesViewEntityMapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    supportedCountriesDomainEntityList,
+                    null,
+                ),
+            ).willReturn(
+                listOf(supportedCountriesViewEntity),
+            )
+
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val payText = "pay £ 100"
+            val expected = CardDetailsCheckoutState(
+                toolbarTitle = "toolBarTitle",
+                orderId = "",
+                merchantName = "",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = true,
+                supportedCountriesList = listOf(supportedCountriesViewEntity),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "EGP",
+                    countryCode = "EG",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                isPostalCodeFieldRequired = true,
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(text = payText),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
-    fun `when payment intent flow collect with collect userId viewModel should emit state with save card checkBox and default as true`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    customerId = "customerId",
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
-        val payText = "pay £ 100"
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val expected = CardDetailsCheckoutState(
-            orderId = "",
-            merchantName = "",
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = true,
-            supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(
+    fun `when payment intent flow collect with collect userId viewModel should emit state with save card checkBox and default as true`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            isPostalCodeFieldRequired = true,
-            checkBoxItem = CheckBoxItem(
-                isVisible = true,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(text = payText),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            val supportedCountriesDomainEntityList = listOf(
+                SupportedCountriesDomainEntity("", "", false),
+            )
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        customerId = "customerId",
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                supportedCountriesDomainEntityList,
+            )
+            given(
+                supportedCountriesViewEntityMapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    supportedCountriesDomainEntityList,
+                    null,
+                ),
+            ).willReturn(
+                listOf(supportedCountriesViewEntity),
+            )
+            val payText = "pay £ 100"
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val expected = CardDetailsCheckoutState(
+                orderId = "",
+                merchantName = "",
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = true,
+                supportedCountriesList = listOf(supportedCountriesViewEntity),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "EGP",
+                    countryCode = "EG",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                isPostalCodeFieldRequired = true,
+                checkBoxItem = CheckBoxItem(
+                    isVisible = true,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(text = payText),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
-    fun `when onPayWithCardClicked called with success from  getRefreshedPaymentTokenFlow ,executeCardPayment from dojoCardPaymentHandler should be called and viewModel state should emits Loading on action button`() = runTest {
-        // arrange
-        val fullCardPaymentPayload: DojoCardPaymentPayLoad.FullCardPaymentPayload = mockk()
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        given(getRefreshedPaymentTokenFlow.getUpdatedPaymentTokenFlow()).willReturn(
-            MutableStateFlow(
-                RefreshPaymentIntentResult.Success(token = "token"),
-            ),
-        )
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
+    fun `when onPayWithCardClicked called with success from  getRefreshedPaymentTokenFlow ,executeCardPayment from dojoCardPaymentHandler should be called and viewModel state should emits Loading on action button`() =
+        runTest {
+            // arrange
+            val fullCardPaymentPayload: DojoCardPaymentPayLoad.FullCardPaymentPayload = mockk()
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            val supportedCountriesDomainEntityList = listOf(
                 SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
-        given(
-            cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(
-                any(),
-                any(),
-            ),
-        ).willReturn(
-            fullCardPaymentPayload,
-        )
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val payText = "pay £ 100"
-        val expected = CardDetailsCheckoutState(
-            orderId = "",
-            merchantName = "",
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = true,
-            supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(
+            )
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(getRefreshedPaymentTokenFlow.getUpdatedPaymentTokenFlow()).willReturn(
+                MutableStateFlow(
+                    RefreshPaymentIntentResult.Success(token = "token"),
+                ),
+            )
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            isPostalCodeFieldRequired = true,
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(isLoading = true, text = payText),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        viewModel.onPayWithCardClicked()
-        // assert
-        verify(updatePaymentStateUseCase).updatePaymentSate(any())
-        verify(dojoCardPaymentHandler).executeCardPayment(any(), any())
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                supportedCountriesDomainEntityList,
+            )
+            given(
+                supportedCountriesViewEntityMapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    supportedCountriesDomainEntityList,
+                    null,
+                ),
+            ).willReturn(
+                listOf(supportedCountriesViewEntity),
+            )
+            given(
+                cardCheckOutFullCardPaymentPayloadMapper.getPaymentPayLoad(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(
+                fullCardPaymentPayload,
+            )
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val payText = "pay £ 100"
+            val expected = CardDetailsCheckoutState(
+                orderId = "",
+                merchantName = "",
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = true,
+                supportedCountriesList = listOf(supportedCountriesViewEntity),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "EGP",
+                    countryCode = "EG",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                isPostalCodeFieldRequired = true,
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(isLoading = true, text = payText),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            viewModel.onPayWithCardClicked()
+            // assert
+            verify(updatePaymentStateUseCase).updatePaymentSate(any())
+            verify(dojoCardPaymentHandler).executeCardPayment(any(), any())
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
-    fun `when onPayWithCardClicked called with failure from  getRefreshedPaymentTokenFlow , viewModel  should call navigateToCardResult`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        given(getRefreshedPaymentTokenFlow.getUpdatedPaymentTokenFlow()).willReturn(
-            MutableStateFlow(
-                RefreshPaymentIntentResult.RefreshFailure,
-            ),
-        )
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
+    fun `when onPayWithCardClicked called with failure from  getRefreshedPaymentTokenFlow , viewModel  should call navigateToCardResult`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(getRefreshedPaymentTokenFlow.getUpdatedPaymentTokenFlow()).willReturn(
+                MutableStateFlow(
+                    RefreshPaymentIntentResult.RefreshFailure,
                 ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val captor = argumentCaptor<DojoPaymentResult>()
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        viewModel.onPayWithCardClicked()
-        // assert
-        verify(updatePaymentStateUseCase).updatePaymentSate(any())
-        verify(navigateToCardResult).invoke(captor.capture())
-        Assert.assertEquals(DojoPaymentResult.SDK_INTERNAL_ERROR, captor.firstValue)
-    }
+            )
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedIcons = listOf(1, 2, 3)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                listOf(
+                    SupportedCountriesDomainEntity("", "", false),
+                ),
+            )
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val captor = argumentCaptor<DojoPaymentResult>()
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            viewModel.onPayWithCardClicked()
+            // assert
+            verify(updatePaymentStateUseCase).updatePaymentSate(any())
+            verify(navigateToCardResult).invoke(captor.capture())
+            Assert.assertEquals(DojoPaymentResult.SDK_INTERNAL_ERROR, captor.firstValue)
+        }
 
     @Test
-    fun `when  onCardHolderValueChanged called state should have the new value and should be emitted`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        given(cardCheckoutScreenValidator.isCardNumberValid(any())).willReturn(true)
-        given(cardCheckoutScreenValidator.isCvvValid(any())).willReturn(true)
-        given(cardCheckoutScreenValidator.isCardExpireDateValid(any())).willReturn(true)
-        given(
-            cardCheckoutScreenValidator.isEmailFieldValidWithInputFieldVisibility(
-                any(),
-                any(),
-            ),
-        ).willReturn(true)
-        given(
-            cardCheckoutScreenValidator.isPostalCodeFieldWithInputFieldVisibility(
-                any(),
-                any(),
-            ),
-        ).willReturn(true)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
+    fun `when  onCardHolderValueChanged called state should have the new value and should be emitted`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            val supportedCountriesDomainEntityList = listOf(
                 SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
-        val payText = "pay £ 100"
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val expected = CardDetailsCheckoutState(
-            orderId = "",
-            merchantName = "",
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = true,
-            supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(
+            )
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            given(cardCheckoutScreenValidator.isCardNumberValid(any())).willReturn(true)
+            given(cardCheckoutScreenValidator.isCvvValid(any())).willReturn(true)
+            given(cardCheckoutScreenValidator.isCardExpireDateValid(any())).willReturn(true)
+            given(
+                cardCheckoutScreenValidator.isEmailFieldValidWithInputFieldVisibility(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
+            given(
+                cardCheckoutScreenValidator.isPostalCodeFieldWithInputFieldVisibility(
+                    any(),
+                    any(),
+                ),
+            ).willReturn(true)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = "new"),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            isPostalCodeFieldRequired = true,
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(isEnabled = false, text = payText),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                supportedCountriesDomainEntityList,
+            )
+            given(
+                supportedCountriesViewEntityMapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    supportedCountriesDomainEntityList,
+                    null,
+                ),
+            ).willReturn(
+                listOf(supportedCountriesViewEntity),
+            )
+            val payText = "pay £ 100"
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val expected = CardDetailsCheckoutState(
+                orderId = "",
+                merchantName = "",
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = true,
+                supportedCountriesList = listOf(supportedCountriesViewEntity),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "EGP",
+                    countryCode = "EG",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = "new"),
+                emailInputField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                isPostalCodeFieldRequired = true,
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(isEnabled = false, text = payText),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
 
-        viewModel.onCardHolderValueChanged("new")
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+            viewModel.onCardHolderValueChanged("new")
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
-    fun `when all card related fields is edited state should have the new values and should be emitted`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
-        val payText = "pay £ 100"
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val expected = CardDetailsCheckoutState(
-            orderId = "",
-            merchantName = "",
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = true,
-            supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(
+    fun `when all card related fields is edited state should have the new values and should be emitted`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = ""),
-            isEmailInputFieldRequired = false,
-            cardNumberInputField = InputFieldState(value = "new"),
-            cardExpireDateInputField = InputFieldState(value = "new"),
-            cvvInputFieldState = InputFieldState(value = "new"),
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            isPostalCodeFieldRequired = true,
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(text = payText),
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        viewModel.onCardNumberValueChanged("new")
-        viewModel.onCvvValueChanged("new")
-        viewModel.onExpireDateValueChanged("new")
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            val supportedCountriesDomainEntityList = listOf(
+                SupportedCountriesDomainEntity("", "", false),
+            )
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                supportedCountriesDomainEntityList,
+            )
+            given(
+                supportedCountriesViewEntityMapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    supportedCountriesDomainEntityList,
+                    null,
+                ),
+            ).willReturn(
+                listOf(supportedCountriesViewEntity),
+            )
+            val payText = "pay £ 100"
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val expected = CardDetailsCheckoutState(
+                orderId = "",
+                merchantName = "",
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = true,
+                supportedCountriesList = listOf(supportedCountriesViewEntity),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "EGP",
+                    countryCode = "EG",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = ""),
+                isEmailInputFieldRequired = false,
+                cardNumberInputField = InputFieldState(value = "new"),
+                cardExpireDateInputField = InputFieldState(value = "new"),
+                cvvInputFieldState = InputFieldState(value = "new"),
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                isPostalCodeFieldRequired = true,
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(text = payText),
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            viewModel.onCardNumberValueChanged("new")
+            viewModel.onCvvValueChanged("new")
+            viewModel.onExpireDateValueChanged("new")
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
-    fun `when onEmailValueChanged called  state should have the new value and should be emitted`() = runTest {
-        // arrange
-        val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> = MutableStateFlow(null)
-        given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
-        val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
-        val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-            countryName = "EGP",
-            countryCode = "EG",
-            isPostalCodeEnabled = true,
-        )
-        val supportedIcons = listOf(1, 2, 3)
-        given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
-        paymentIntentFakeFlow.tryEmit(
-            PaymentIntentResult.Success(
-                result = PaymentIntentDomainEntity(
-                    "id",
-                    "token",
-                    AmountDomainEntity(
-                        10L,
-                        "100",
-                        "GBP",
-                    ),
-                    supportedCardsSchemes = listOf(CardsSchemes.AMEX),
-                    collectionBillingAddressRequired = true,
-                    collectionEmailRequired = true,
-                ),
-            ),
-        )
-        paymentStateFakeFlow.tryEmit(true)
-        given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
-            listOf(
-                SupportedCountriesDomainEntity("", "", false),
-            ),
-        )
-        given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-            supportedCountriesViewEntity,
-        )
-        val payText = "pay £ 100"
-        given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
-        val expected = CardDetailsCheckoutState(
-            orderId = "",
-            merchantName = "",
-            toolbarTitle = "toolBarTitle",
-            totalAmount = "100",
-            amountCurrency = "£",
-            isBillingCountryFieldRequired = true,
-            supportedCountriesList = listOf(supportedCountriesViewEntity),
-            currentSelectedCountry = SupportedCountriesViewEntity(
+    fun `when onEmailValueChanged called  state should have the new value and should be emitted`() =
+        runTest {
+            // arrange
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult?> =
+                MutableStateFlow(null)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(true)
+            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
                 countryName = "EGP",
                 countryCode = "EG",
                 isPostalCodeEnabled = true,
-            ),
-            allowedPaymentMethodsIcons = listOf(1, 2, 3),
-            cardHolderInputField = InputFieldState(value = ""),
-            emailInputField = InputFieldState(value = "new"),
-            isEmailInputFieldRequired = true,
-            checkBoxItem = CheckBoxItem(
-                isVisible = false,
-                isChecked = true,
-                messageText = "checkBoxMessage",
-            ),
-            cardNumberInputField = InputFieldState(value = ""),
-            cardExpireDateInputField = InputFieldState(value = ""),
-            cvvInputFieldState = InputFieldState(value = ""),
-            isPostalCodeFieldRequired = true,
-            postalCodeField = InputFieldState(value = ""),
-            actionButtonState = ActionButtonState(text = payText),
+            )
+            val supportedIcons = listOf(1, 2, 3)
+            val supportedCountriesDomainEntityList = listOf(
+                SupportedCountriesDomainEntity("", "", false),
+            )
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+            paymentIntentFakeFlow.tryEmit(
+                PaymentIntentResult.Success(
+                    result = PaymentIntentDomainEntity(
+                        "id",
+                        "token",
+                        AmountDomainEntity(
+                            10L,
+                            "100",
+                            "GBP",
+                        ),
+                        supportedCardsSchemes = listOf(CardsSchemes.AMEX),
+                        collectionBillingAddressRequired = true,
+                        collectionEmailRequired = true,
+                    ),
+                ),
+            )
+            paymentStateFakeFlow.tryEmit(true)
+            given(getSupportedCountriesUseCase.getSupportedCountries()).willReturn(
+                supportedCountriesDomainEntityList,
+            )
+            given(
+                supportedCountriesViewEntityMapper.mapToSupportedCountriesViewEntityWithPreSelectedCountry(
+                    supportedCountriesDomainEntityList,
+                    null,
+                ),
+            ).willReturn(
+                listOf(supportedCountriesViewEntity),
+            )
+            val payText = "pay £ 100"
+            given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
+            val expected = CardDetailsCheckoutState(
+                orderId = "",
+                merchantName = "",
+                toolbarTitle = "toolBarTitle",
+                totalAmount = "100",
+                amountCurrency = "£",
+                isBillingCountryFieldRequired = true,
+                supportedCountriesList = listOf(supportedCountriesViewEntity),
+                currentSelectedCountry = SupportedCountriesViewEntity(
+                    countryName = "EGP",
+                    countryCode = "EG",
+                    isPostalCodeEnabled = true,
+                ),
+                allowedPaymentMethodsIcons = listOf(1, 2, 3),
+                cardHolderInputField = InputFieldState(value = ""),
+                emailInputField = InputFieldState(value = "new"),
+                isEmailInputFieldRequired = true,
+                checkBoxItem = CheckBoxItem(
+                    isVisible = false,
+                    isChecked = true,
+                    messageText = "checkBoxMessage",
+                ),
+                cardNumberInputField = InputFieldState(value = ""),
+                cardExpireDateInputField = InputFieldState(value = ""),
+                cvvInputFieldState = InputFieldState(value = ""),
+                isPostalCodeFieldRequired = true,
+                postalCodeField = InputFieldState(value = ""),
+                actionButtonState = ActionButtonState(text = payText),
 
-        )
-        // act
-        val viewModel = CardDetailsCheckoutViewModel(
-            observePaymentIntent,
-            dojoCardPaymentHandler,
-            observePaymentStatus,
-            updatePaymentStateUseCase,
-            getSupportedCountriesUseCase,
-            supportedCountriesViewEntityMapper,
-            allowedPaymentMethodsViewEntityMapper,
-            cardCheckoutScreenValidator,
-            cardCheckOutFullCardPaymentPayloadMapper,
-            stringProvider,
-            isStartDestination,
-            refreshPaymentIntentUseCase,
-            getRefreshedPaymentTokenFlow,
-            navigateToCardResult,
-        )
-        viewModel.onEmailValueChanged("new")
-        // assert
-        Assert.assertEquals(expected, viewModel.state.value)
-    }
+            )
+            // act
+            val viewModel = CardDetailsCheckoutViewModel(
+                observePaymentIntent,
+                dojoCardPaymentHandler,
+                observePaymentStatus,
+                updatePaymentStateUseCase,
+                getSupportedCountriesUseCase,
+                supportedCountriesViewEntityMapper,
+                allowedPaymentMethodsViewEntityMapper,
+                cardCheckoutScreenValidator,
+                cardCheckOutFullCardPaymentPayloadMapper,
+                stringProvider,
+                isStartDestination,
+                refreshPaymentIntentUseCase,
+                getRefreshedPaymentTokenFlow,
+                navigateToCardResult,
+            )
+            viewModel.onEmailValueChanged("new")
+            // assert
+            Assert.assertEquals(expected, viewModel.state.value)
+        }
 
     @Test
     fun `when any of cardCheckoutScreenValidator methods return false action button should be disabled`() =
@@ -929,11 +977,6 @@ class CardDetailsCheckoutViewModelTest {
             given(cardCheckoutScreenValidator.isCvvValid(any())).willReturn(false)
             given(cardCheckoutScreenValidator.isCardExpireDateValid(any())).willReturn(false)
             given(cardCheckoutScreenValidator.isEmailValid(any())).willReturn(false)
-            val supportedCountriesViewEntity = SupportedCountriesViewEntity(
-                countryName = "EGP",
-                countryCode = "EG",
-                isPostalCodeEnabled = true,
-            )
             val supportedIcons = listOf(1, 2, 3)
             given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
             paymentIntentFakeFlow.tryEmit(
@@ -957,9 +1000,6 @@ class CardDetailsCheckoutViewModelTest {
                 listOf(
                     SupportedCountriesDomainEntity("", "", false),
                 ),
-            )
-            given(supportedCountriesViewEntityMapper.apply(any())).willReturn(
-                supportedCountriesViewEntity,
             )
             given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
             // act


### PR DESCRIPTION
## WHAT 
- pre fill the email field and billing address related fields from Payment Intent if exists 
## HOW
- make payment intent raw domain  objects supports the new fields 
- add the needed mapping logic in the domain mapper 
- update the cardCheckput viewModel to use the new data 
- update and add needed unit tests 