### PR TITLE
Feature/pppp 447 preventing log rocket and similar tools from accessing sdk payment fields

### DIFF
--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -120,6 +121,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     private fun lockToPortrait() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
     }
 
     private fun configureDojoPayCore() {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -81,6 +81,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        disableScreenRecord()
         lockToPortrait()
         configureDojoSDKDebugConfig()
         configureDojoPayCore()
@@ -121,7 +122,15 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     private fun lockToPortrait() {
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        window.setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE)
+    }
+
+    private fun disableScreenRecord() {
+        if (!paymentFlowViewModel.isPaymentInSandBoxEnvironment()) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE,
+            )
+        }
     }
 
     private fun configureDojoPayCore() {


### PR DESCRIPTION
## what 
- disable screen record on prod Payments id only 