### PR TITLE
Feature/pppp 447 preventing log rocket and similar tools from accessing sdk payment fields

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -31,7 +31,10 @@ class UiSdkSampleActivity : AppCompatActivity() {
         setCustomerCreationListener()
 
         uiSdkSampleBinding.startPaymentFlow.setOnClickListener {
-            DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = false)
+            DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(
+                forceLightMode = false,
+                analyticsExcludedFieldsIdentifier = "lr-show",
+            )
             dojoPayUI.startPaymentFlow(
                 DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),
             )

--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -31,10 +31,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
         setCustomerCreationListener()
 
         uiSdkSampleBinding.startPaymentFlow.setOnClickListener {
-            DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(
-                forceLightMode = false,
-                analyticsExcludedFieldsIdentifier = "lr-hide"
-            )
+            DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = false)
             dojoPayUI.startPaymentFlow(
                 DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),
             )

--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -33,7 +33,7 @@ class UiSdkSampleActivity : AppCompatActivity() {
         uiSdkSampleBinding.startPaymentFlow.setOnClickListener {
             DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(
                 forceLightMode = false,
-                analyticsExcludedFieldsIdentifier = "lr-show",
+                analyticsExcludedFieldsIdentifier = "lr-hide"
             )
             dojoPayUI.startPaymentFlow(
                 DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),

--- a/sdk/src/main/java/tech/dojo/pay/sdk/paymentmethods/PaymentMethodsProvider.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/paymentmethods/PaymentMethodsProvider.kt
@@ -11,7 +11,7 @@ import tech.dojo.pay.sdk.paymentmethods.data.PaymentMethodsRepository
 internal class PaymentMethodsProvider(
     private val paymentMethodsRepository: PaymentMethodsRepository = PaymentMethodsRepository(
         api = PaymentMethodsApiBuilder().create(),
-        ),
+    ),
 ) {
     fun fetchPaymentMethods(
         customerId: String,

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
@@ -10,6 +10,7 @@ data class DojoThemeSettings @JvmOverloads constructor(
     val darkColorPalette: DarkColorPalette = DarkColorPalette(),
     val forceLightMode: Boolean = false,
     val showBranding: Boolean = true,
+    val analyticsExcludedFieldsIdentifier:String = ""
 ) : Serializable
 
 @Keep

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
@@ -10,7 +10,7 @@ data class DojoThemeSettings @JvmOverloads constructor(
     val darkColorPalette: DarkColorPalette = DarkColorPalette(),
     val forceLightMode: Boolean = false,
     val showBranding: Boolean = true,
-    val analyticsExcludedFieldsIdentifier:String = ""
+    val analyticsExcludedFieldsIdentifier: String = ""
 ) : Serializable
 
 @Keep

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -119,11 +119,6 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         }
     }
 
-    @SuppressLint("SourceLockedOrientationActivity")
-    private fun lockToPortrait() {
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    }
-
     private fun disableScreenRecord() {
         if (!paymentFlowViewModel.isPaymentInSandBoxEnvironment()) {
             window.setFlags(
@@ -131,6 +126,11 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 WindowManager.LayoutParams.FLAG_SECURE,
             )
         }
+    }
+
+    @SuppressLint("SourceLockedOrientationActivity")
+    private fun lockToPortrait() {
+        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
     }
 
     private fun configureDojoPayCore() {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/InputFieldModifierWithFocusChangedAndScrollingLogic.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/InputFieldModifierWithFocusChangedAndScrollingLogic.kt
@@ -30,7 +30,7 @@ internal fun Modifier.autoScrollableInputFieldOnFocusChangeAndValidator(
         if (focusState.isFocused) {
             coroutineScope.launch {
                 delay(300)
-                val totalOffset =  scrollOffsets.maxOrNull() ?: 0F
+                val totalOffset = scrollOffsets.maxOrNull() ?: 0F
                 if (totalOffset != 0F) {
                     scrollState.animateScrollTo((parentPosition + totalOffset - inputFieldLabelHeightInPx).roundToInt())
                 } else {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/LabelAndAssistiveTextWrapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/LabelAndAssistiveTextWrapper.kt
@@ -11,21 +11,24 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import tech.dojo.pay.uisdk.DojoSDKDropInUI
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 
 @Composable
 internal fun LabelAndAssistiveTextWrapper(
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
+        .testTag(DojoSDKDropInUI.dojoThemeSettings?.analyticsExcludedFieldsIdentifier?: ""),
     label: AnnotatedString? = null,
     assistiveText: AnnotatedString? = null,
     isError: Boolean = false,
     enabled: Boolean = true,
-    content: @Composable () -> Unit
+    content: @Composable () -> Unit,
 ) {
     Column(modifier = modifier) {
         if (!label.isNullOrEmpty()) {
@@ -40,7 +43,7 @@ internal fun LabelAndAssistiveTextWrapper(
             AssistiveText(
                 text = assistiveText,
                 enabled = enabled,
-                isError = isError
+                isError = isError,
             )
         }
     }
@@ -49,14 +52,14 @@ internal fun LabelAndAssistiveTextWrapper(
 @Composable
 internal fun Label(
     text: AnnotatedString,
-    enabled: Boolean
+    enabled: Boolean,
 ) {
     Text(
         text = text,
         style = DojoTheme.typography.subtitle1,
         color = DojoTheme.colors.primaryLabelTextColor.copy(
-            alpha = if (enabled) ContentAlpha.high else ContentAlpha.disabled
-        )
+            alpha = if (enabled) ContentAlpha.high else ContentAlpha.disabled,
+        ),
     )
 }
 
@@ -64,7 +67,7 @@ internal fun Label(
 internal fun AssistiveText(
     text: AnnotatedString,
     enabled: Boolean,
-    isError: Boolean
+    isError: Boolean,
 ) {
     Row() {
         if (isError) {
@@ -72,7 +75,7 @@ internal fun AssistiveText(
                 modifier = Modifier.padding(end = 8.dp),
                 painter = painterResource(id = R.drawable.ic_error_18),
                 tint = DojoTheme.colors.errorTextColor,
-                contentDescription = null
+                contentDescription = null,
             )
         }
         Text(
@@ -81,9 +84,9 @@ internal fun AssistiveText(
             color = when {
                 isError -> DojoTheme.colors.errorTextColor
                 else -> LocalContentColor.current.copy(
-                    alpha = if (enabled) ContentAlpha.medium else ContentAlpha.disabled
+                    alpha = if (enabled) ContentAlpha.medium else ContentAlpha.disabled,
                 )
-            }
+            },
         )
     }
 }
@@ -95,11 +98,11 @@ fun AssistiveTextPreview() {
         LabelAndAssistiveTextWrapper(
             label = AnnotatedString("Label"),
             assistiveText = AnnotatedString("Assistive text"),
-            isError = true
+            isError = true,
         ) {
             Text(
                 modifier = Modifier.background(Color.Magenta),
-                text = "Lorem ipsum dolor sit amet"
+                text = "Lorem ipsum dolor sit amet",
             )
         }
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/LabelAndAssistiveTextWrapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/LabelAndAssistiveTextWrapper.kt
@@ -22,15 +22,17 @@ import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 
 @Composable
 internal fun LabelAndAssistiveTextWrapper(
-    modifier: Modifier = Modifier
-        .testTag(DojoSDKDropInUI.dojoThemeSettings?.analyticsExcludedFieldsIdentifier?: ""),
+    modifier: Modifier = Modifier,
     label: AnnotatedString? = null,
     assistiveText: AnnotatedString? = null,
     isError: Boolean = false,
     enabled: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    Column(modifier = modifier) {
+    Column(modifier = modifier
+        .then(Modifier.testTag(
+            DojoSDKDropInUI.dojoThemeSettings?.analyticsExcludedFieldsIdentifier?: ""))
+    ) {
         if (!label.isNullOrEmpty()) {
             Label(text = label, enabled = enabled)
             DojoSpacer(height = 6.dp)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/LabelAndAssistiveTextWrapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/LabelAndAssistiveTextWrapper.kt
@@ -29,9 +29,13 @@ internal fun LabelAndAssistiveTextWrapper(
     enabled: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    Column(modifier = modifier
-        .then(Modifier.testTag(
-            DojoSDKDropInUI.dojoThemeSettings?.analyticsExcludedFieldsIdentifier?: ""))
+    Column(
+        modifier = modifier
+            .then(
+                Modifier.testTag(
+                    DojoSDKDropInUI.dojoThemeSettings?.analyticsExcludedFieldsIdentifier ?: "",
+                ),
+            ),
     ) {
         if (!label.isNullOrEmpty()) {
             Label(text = label, enabled = enabled)


### PR DESCRIPTION
## what 
- add custom tags ` analyticsExcludedFieldsIdentifier` for them settings to hid input fields 