### PR TITLE
Feature/update to compose 1.5.0 and Kotlin 1.9.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0")
-        classpath("com.android.tools.build:gradle:7.2.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
+        classpath("com.android.tools.build:gradle:7.4.1")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
         classpath("org.jetbrains.dokka:dokka-core:1.5.0")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.5.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ buildscript {
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
         classpath("com.android.tools.build:gradle:7.4.1")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.5.0")
-        classpath("org.jetbrains.dokka:dokka-core:1.5.0")
+//        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.8.20")
+//        classpath("org.jetbrains.dokka:dokka-core:1.8.20")
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:2.5.1")
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,11 +7,10 @@ repositories {
 }
 
 object Plugins {
-    const val AGP = "7.3.1"
+    const val AGP = "7.4.1"
     const val DOKKA = "1.5.0"
-    const val KOTLIN = "1.8.10"
+    const val KOTLIN = "1.9.0"
 }
-
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${Plugins.KOTLIN}")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,13 +8,13 @@ repositories {
 
 object Plugins {
     const val AGP = "7.4.1"
-    const val DOKKA = "1.5.0"
+    const val DOKKA = "1.8.20"
     const val KOTLIN = "1.9.0"
 }
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${Plugins.KOTLIN}")
     implementation("com.android.tools.build:gradle:${Plugins.AGP}")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:${Plugins.DOKKA}")
-    implementation("org.jetbrains.dokka:dokka-core:${Plugins.DOKKA}")
+//    implementation("org.jetbrains.dokka:dokka-gradle-plugin:${Plugins.DOKKA}")
+//    implementation("org.jetbrains.dokka:dokka-core:${Plugins.DOKKA}")
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.com.google.gson.Gson
+
 
 object Sdk {
     const val MIN_SDK_VERSION = 21
@@ -22,7 +22,7 @@ object Versions {
     const val ESPRESSO_CORE = "3.4.0"
     const val JUNIT = "4.13.2"
     const val KTLINT = "0.43.2"
-    const val COMPOSE_VERSION = "1.4.2"
+    const val COMPOSE_VERSION = "1.5.0"
     const val COMPOSE_ANIMATION_VERSION = "1.5.0-alpha01"
     const val KOTLIN = "1.8.1"
     const val ACCOMPANIST = "0.23.0"
@@ -36,13 +36,13 @@ object Versions {
     const val COMPOSE_NAVIGATION_ANIMATION = "0.23.1"
     const val TIMBER = "5.0.1"
     const val GSON = "2.8.7"
-    const val csvReader= "1.6.0"
-    const val ANDROIDX_WINDOW= "1.0.0"
-    const val RETROFIT= "2.9.0"
-    const val GPAY= "19.1.0"
-    const val JSON_TEST= "20180813"
-    const val CARDINAL= "2.2.7-3"
-    const val MOCKK="1.13.4"
+    const val csvReader = "1.6.0"
+    const val ANDROIDX_WINDOW = "1.0.0"
+    const val RETROFIT = "2.9.0"
+    const val GPAY = "19.1.0"
+    const val JSON_TEST = "20180813"
+    const val CARDINAL = "2.2.7-3"
+    const val MOCKK = "1.13.4"
 }
 
 object BuildPluginsVersion {
@@ -61,7 +61,6 @@ object Accompanist {
 object MOCKITO {
     const val MOCKITO_KOTLIN = "org.mockito.kotlin:mockito-kotlin:${Versions.MOCKITO}"
     const val MOCKITO_INLINE = "org.mockito:mockito-inline:${Versions.MOCKITO_IN_LINE}"
-
 }
 
 object Coroutines {
@@ -69,7 +68,6 @@ object Coroutines {
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.COROUTINES}"
     const val COROUTINES_Test =
         "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.COROUTINES}"
-
 }
 
 object DojoPayCore {
@@ -96,9 +94,8 @@ object Navigation {
         "androidx.navigation:navigation-compose:${Versions.COMPOSE_NAVIGATION}"
     const val NavigationAnimationCompose =
         "com.google.accompanist:accompanist-navigation-animation:${Versions.COMPOSE_NAVIGATION_ANIMATION}"
-
 }
-object CsvReader{
+object CsvReader {
     const val csvReader = "com.github.doyaaaaaken:kotlin-csv-jvm:${Versions.csvReader}"
 }
 object AndroidX {
@@ -108,7 +105,6 @@ object AndroidX {
     const val VIEWBINDING = "androidx.databinding:viewbinding:${Versions.VIEWBINDING}"
     const val CORE_TESTING_ARCH = "androidx.arch.core:core-testing:2.1.0"
     const val WINDOW = "androidx.window:window:${Versions.ANDROIDX_WINDOW}"
-
 
     object Activity {
 
@@ -124,7 +120,6 @@ object AndroidX {
 
         // Compose Integration with activities
         const val FRAGMENT = "androidx.fragment:fragment-ktx:${Versions.FRAGMENT}"
-
     }
 
     object Lifecycle {
@@ -134,7 +129,6 @@ object AndroidX {
             "androidx.lifecycle:lifecycle-viewmodel-compose:${Versions.VIEWMODEL_COMPOSE}"
 
         const val VIEWMODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.VIEWMODEL}"
-
     }
 
     object Compose {
@@ -183,26 +177,22 @@ object AndroidX {
         const val ESPRESSO_CORE = "androidx.test.espresso:espresso-core:${Versions.ESPRESSO_CORE}"
     }
 
-
-
     object Logging {
         const val TIMBER = "com.jakewharton.timber:timber:${Versions.TIMBER}"
     }
-
-
 }
 object Networking {
-    const val RETROFIT_CORE= "com.squareup.retrofit2:retrofit:${Versions.RETROFIT}"
-    const val CONVERTER_GSON= "com.squareup.retrofit2:converter-gson:${Versions.RETROFIT}"
-    const val CONVERTER_SCALARS="com.squareup.retrofit2:converter-scalars:${Versions.RETROFIT}"
+    const val RETROFIT_CORE = "com.squareup.retrofit2:retrofit:${Versions.RETROFIT}"
+    const val CONVERTER_GSON = "com.squareup.retrofit2:converter-gson:${Versions.RETROFIT}"
+    const val CONVERTER_SCALARS = "com.squareup.retrofit2:converter-scalars:${Versions.RETROFIT}"
 }
 
-object Wallet{
-    const val GPAY="com.google.android.gms:play-services-wallet:${Versions.GPAY}"
+object Wallet {
+    const val GPAY = "com.google.android.gms:play-services-wallet:${Versions.GPAY}"
 }
 
-object Threeds{
-    const val Cardinal="org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:${Versions.CARDINAL}"
+object Threeds {
+    const val Cardinal = "org.jfrog.cardinalcommerce.gradle:cardinalmobilesdk:${Versions.CARDINAL}"
 }
 object TestingLib {
 
@@ -210,6 +200,5 @@ object TestingLib {
 
     const val JSON_TEST = "org.json:json:${Versions.JSON_TEST}"
 
-    const val MOCKK="io.mockk:mockk:${Versions.MOCKK}"
-
+    const val MOCKK = "io.mockk:mockk:${Versions.MOCKK}"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -24,7 +24,7 @@ object Versions {
     const val KTLINT = "0.43.2"
     const val COMPOSE_VERSION = "1.5.0"
     const val COMPOSE_ANIMATION_VERSION = "1.5.0-alpha01"
-    const val KOTLIN = "1.8.1"
+    const val KOTLIN = "1.9.0"
     const val ACCOMPANIST = "0.23.0"
     const val COROUTINES = "1.6.1"
     const val MATERIAL = "1.5.0"
@@ -75,7 +75,6 @@ object DojoPayCore {
 }
 
 object Kotlin {
-
     const val stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.KOTLIN}"
     const val reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.KOTLIN}"
     const val extensions = "org.jetbrains.kotlin:kotlin-android-extensions:${Versions.KOTLIN}"

--- a/buildSrc/src/main/kotlin/publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/publish.gradle.kts
@@ -21,7 +21,7 @@ import java.util.*
 
 plugins {
     id("maven-publish")
-    id("org.jetbrains.dokka")
+//    id("org.jetbrains.dokka")
 }
 
 group = "tech.dojo.pay"
@@ -36,18 +36,18 @@ val sourcesJar = tasks.register<Jar>("sourcesJar") {
         from((project.extensions.getByName("sourceSets") as SourceSetContainer).named("main").get().allSource)
     }
 }
+//
+// val dokkaJar = tasks.create<Jar>("dokkaJar") {
+//    group = JavaBasePlugin.DOCUMENTATION_GROUP
+//    description = "Javadoc jar from Analytics"
+//    archiveClassifier.set("javadoc")
+// //    from(tasks.dokkaJavadoc)
+// //    dependsOn(tasks.dokkaJavadoc)
+// }
 
-val dokkaJar = tasks.create<Jar>("dokkaJar") {
-    group = JavaBasePlugin.DOCUMENTATION_GROUP
-    description = "Javadoc jar from Analytics"
-    archiveClassifier.set("javadoc")
-    from(tasks.dokkaJavadoc)
-    dependsOn(tasks.dokkaJavadoc)
-}
-
-tasks.dokkaJavadoc.configure {
-    outputDirectory.set(buildDir.resolve("javadoc"))
-}
+// tasks.dokkaJavadoc.configure {
+//    outputDirectory.set(buildDir.resolve("javadoc"))
+// }
 
 /**Create credentials.properties in root project folder file with gpr.user=GITHUB_USER_ID  & gpr.key=PERSONAL_ACCESS_TOKEN**/
 // val credentialProperties = Properties()
@@ -76,7 +76,7 @@ afterEvaluate {
                 }
 
                 artifact(sourcesJar)
-                artifact(dokkaJar)
+//                artifact(dokkaJar)
 
                 pom {
                     if (!"USE_SNAPSHOT".byProperty.isNullOrBlank()) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jun 08 15:41:31 BST 2023
+#Sun Oct 29 21:02:09 GMT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,12 +6,12 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 android {
-    compileSdk 34
 
     defaultConfig {
+        compileSdk 34
         applicationId "tech.dojo.pay.sdksample"
-        minSdk 21
-        targetSdk 33
+        minSdk 26
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -51,4 +51,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    implementation 'androidx.compose.compiler:compiler:1.5.0'
+    implementation 'androidx.compose.ui:ui:1.5.0'
+    implementation 'androidx.compose.runtime:runtime:1.5.0'
+    implementation 'androidx.compose.material:material:1.5.0'
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,7 +6,7 @@ def keystorePropertiesFile = rootProject.file("keystore.properties")
 def keystoreProperties = new Properties()
 keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
 android {
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "tech.dojo.pay.sdksample"

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.6.0"
+version = "1.6.0-test"
 
 plugins {
     id("com.android.library")
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -34,7 +34,7 @@ android {
     kotlinOptions {
         jvmTarget = "11"
         freeCompilerArgs = listOf(
-            "-Xopt-in=kotlin.RequiresOptIn",
+            "-opt-in=kotlin.RequiresOptIn",
         )
     }
     testOptions {

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.6.0-test"
+version = "1.6.0"
 
 plugins {
     id("com.android.library")

--- a/sdk/src/main/java/tech/dojo/pay/sdk/card/presentation/card/viewmodel/DojoVirtualTerminalViewModelFactory.kt
+++ b/sdk/src/main/java/tech/dojo/pay/sdk/card/presentation/card/viewmodel/DojoVirtualTerminalViewModelFactory.kt
@@ -9,7 +9,7 @@ import tech.dojo.pay.sdk.card.data.remote.cardpayment.CardPaymentApiBuilder
 import tech.dojo.pay.sdk.card.entities.DojoCardPaymentParams
 
 internal class DojoVirtualTerminalViewModelFactory(private val arguments: Bundle?) : ViewModelProvider.Factory {
-    override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val args = requireNotNull(arguments)
         val params =
             args.getSerializable(DojoCardPaymentResultContract.KEY_PARAMS) as DojoCardPaymentParams

--- a/uisdk/build.gradle.kts
+++ b/uisdk/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.3.1-test"
+version = "1.3.1"
 
 plugins {
     id("com.android.library")

--- a/uisdk/build.gradle.kts
+++ b/uisdk/build.gradle.kts
@@ -1,4 +1,4 @@
-version = "1.3.1"
+version = "1.3.1-test"
 
 plugins {
     id("com.android.library")
@@ -8,11 +8,11 @@ plugins {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
@@ -42,8 +42,8 @@ android {
     kotlinOptions {
         jvmTarget = "11"
         freeCompilerArgs = listOf(
-            "-Xopt-in=kotlin.RequiresOptIn",
-            "-Xjvm-default=compatibility",
+            "-opt-in=kotlin.RequiresOptIn",
+
         )
     }
     testOptions {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/InputFieldModifierWithFocusChangedAndScrollingLogic.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/InputFieldModifierWithFocusChangedAndScrollingLogic.kt
@@ -24,7 +24,7 @@ internal fun Modifier.autoScrollableInputFieldOnFocusChangeAndValidator(
     onValidate: () -> Unit,
 ): Modifier {
     var hasBeenFocused by remember { mutableStateOf(initialHasBeenFocused) }
-    val scrollOffsets = remember { mutableListOf<Float>() }
+    val scrollOffsets by remember { mutableStateOf(mutableListOf<Float>()) }
     var inputFieldLabelHeightInPx by remember { mutableStateOf(0) }
     return this.onFocusChanged { focusState ->
         if (focusState.isFocused) {

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
@@ -22,7 +22,7 @@ class PaymentResultViewEntityMapperTest {
             .willReturn("Successful Payment")
         val expected = PaymentResultState.SuccessfulResult(
             appBarTitle = "Successful Payment",
-            imageId = 2131230882,
+            imageId = 2131230888,
             status = "Successful Payment",
             orderInfo = "",
             description = "",
@@ -51,7 +51,7 @@ class PaymentResultViewEntityMapperTest {
             .willReturn("Successful Setup Intent")
         val expected = PaymentResultState.SuccessfulResult(
             appBarTitle = "Successful Setup Intent",
-            imageId = 2131230882,
+            imageId = 2131230888,
             status = "Successful Setup Intent",
             orderInfo = "",
             description = "",
@@ -82,7 +82,7 @@ class PaymentResultViewEntityMapperTest {
             .willReturn("Failed Setup Intent")
         val expected = PaymentResultState.FailedResult(
             appBarTitle = "Failed Setup Intent",
-            imageId = 2131230865,
+            imageId = 2131230871,
             status = "Failed Setup Intent",
             details = "Failed Setup Intent",
             shouldNavigateToPreviousScreen = false,
@@ -113,7 +113,7 @@ class PaymentResultViewEntityMapperTest {
             .willReturn("Failed Setup Intent")
         val expected = PaymentResultState.FailedResult(
             appBarTitle = "Failed Setup Intent",
-            imageId = 2131230865,
+            imageId = 2131230871,
             status = "Failed Setup Intent",
             details = "Failed Setup Intent",
             shouldNavigateToPreviousScreen = false,


### PR DESCRIPTION
## what 
- update to compose `1.5.0` along with Kotlin `1.9.0`
- disable Dokka as it's not yet supporting 1.9.0 for kotlin 