### PR TITLE
Fix/move away from local software keyboard controller

### DIFF
--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/KeyboardController.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/KeyboardController.kt
@@ -1,6 +1,27 @@
 package tech.dojo.pay.uisdk.presentation.components
 
-internal interface KeyboardController {
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+
+interface KeyboardController {
     fun show()
     fun hide()
+}
+
+@Composable
+fun rememberKeyboardController(): KeyboardController {
+    val view = LocalView.current
+    val imm =
+        LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+    return remember {
+        object : KeyboardController {
+            override fun show() { imm?.showSoftInput(view, 0) }
+
+            override fun hide() { imm?.hideSoftInputFromWindow(view.windowToken, 0) }
+        }
+    }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/KeyboardController.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/components/KeyboardController.kt
@@ -1,0 +1,6 @@
+package tech.dojo.pay.uisdk.presentation.components
+
+internal interface KeyboardController {
+    fun show()
+    fun hide()
+}

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -1,5 +1,7 @@
 package tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout
 
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -28,15 +30,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
@@ -59,6 +60,7 @@ import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooterModes
 import tech.dojo.pay.uisdk.presentation.components.DojoSpacer
 import tech.dojo.pay.uisdk.presentation.components.HeaderItem
 import tech.dojo.pay.uisdk.presentation.components.InputFieldWithErrorMessage
+import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.MerchantInfoWithSupportedNetworksHeader
 import tech.dojo.pay.uisdk.presentation.components.SingleButtonView
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
@@ -70,7 +72,6 @@ import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.viewmodel.CardDet
 import kotlin.math.roundToInt
 
 @Suppress("LongMethod")
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun CardDetailsCheckoutScreen(
     windowSize: WindowSize,
@@ -81,7 +82,18 @@ internal fun CardDetailsCheckoutScreen(
     showDojoBrand: Boolean,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val view = LocalView.current
+    val keyboardController = object : KeyboardController {
+        val imm = LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+
+        override fun show() {
+            imm?.showSoftInput(view, 0)
+        }
+
+        override fun hide() {
+            imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
     var scrollToPosition by remember { mutableStateOf(0F) }
@@ -263,14 +275,13 @@ private fun ActionButton(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CvvField(
     scrollState: ScrollState,
     coroutineScope: CoroutineScope,
     scrollToPosition: Float,
     state: CardDetailsCheckoutState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     viewModel: CardDetailsCheckoutViewModel,
 ) {
     val scrollOffset = with(LocalDensity.current) {
@@ -305,13 +316,12 @@ private fun CvvField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CardExpireDateField(
     scrollState: ScrollState,
     coroutineScope: CoroutineScope,
     scrollToPosition: Float,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     state: CardDetailsCheckoutState,
     viewModel: CardDetailsCheckoutViewModel,
 ) {
@@ -352,13 +362,12 @@ private fun CardExpireDateField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CardNumberField(
     scrollState: ScrollState,
     coroutineScope: CoroutineScope,
     scrollToPosition: Float,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     state: CardDetailsCheckoutState,
     viewModel: CardDetailsCheckoutViewModel,
     isDarkModeEnabled: Boolean,
@@ -389,7 +398,7 @@ private fun CardNumberField(
             keyboardType = KeyboardType.Number,
             imeAction = ImeAction.Done,
         ),
-        keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+        keyboardActions = KeyboardActions(onDone = { keyboardController.hide() }),
         isError = state.cardNumberInputField.isError,
         assistiveText = state.cardNumberInputField.errorMessages?.let {
             AnnotatedString(it)
@@ -401,13 +410,12 @@ private fun CardNumberField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CardHolderNameField(
     scrollState: ScrollState,
     coroutineScope: CoroutineScope,
     scrollToPosition: Float,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     state: CardDetailsCheckoutState,
     viewModel: CardDetailsCheckoutViewModel,
 ) {
@@ -433,7 +441,7 @@ private fun CardHolderNameField(
             onValidate = { viewModel.validateCardHolder(state.cardHolderInputField.value) },
         ),
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-        keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+        keyboardActions = KeyboardActions(onDone = { keyboardController.hide() }),
         value = state.cardHolderInputField.value,
         isError = state.cardHolderInputField.isError,
         assistiveText = state.cardHolderInputField.errorMessages?.let { AnnotatedString(it) },
@@ -442,14 +450,13 @@ private fun CardHolderNameField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun EmailField(
     scrollState: ScrollState,
     coroutineScope: CoroutineScope,
     scrollToPosition: Float,
     state: CardDetailsCheckoutState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     viewModel: CardDetailsCheckoutViewModel,
 ) {
     if (state.isEmailInputFieldRequired) {
@@ -476,7 +483,7 @@ private fun EmailField(
                 AnnotatedString(it)
             },
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+            keyboardActions = KeyboardActions(onDone = { keyboardController.hide() }),
             value = state.emailInputField.value,
             onValueChange = { viewModel.onEmailValueChanged(it) },
             label = buildAnnotatedString { append(stringResource(R.string.dojo_ui_sdk_card_details_checkout_field_email)) },
@@ -498,14 +505,13 @@ private fun BillingCountryField(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PostalCodeField(
     scrollState: ScrollState,
     coroutineScope: CoroutineScope,
     scrollToPosition: Float,
     state: CardDetailsCheckoutState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     viewModel: CardDetailsCheckoutViewModel,
 ) {
     if (state.isPostalCodeFieldRequired) {
@@ -525,7 +531,7 @@ private fun PostalCodeField(
                 },
             ),
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { keyboardController?.hide() }),
+            keyboardActions = KeyboardActions(onDone = { keyboardController.hide() }),
             value = state.postalCodeField.value,
             isError = state.postalCodeField.isError,
             assistiveText =

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -309,7 +309,7 @@ private fun CvvField(
         isError = state.cvvInputFieldState.isError,
         assistiveText = state.cvvInputFieldState.errorMessages?.let { AnnotatedString(it) },
         keyboardActions = KeyboardActions(onDone = {
-            keyboardController?.hide()
+            keyboardController.hide()
         }),
         cvvPlaceholder = stringResource(R.string.dojo_ui_sdk_card_details_checkout_placeholder_cvv),
         onCvvValueChanged = { viewModel.onCvvValueChanged(it) },
@@ -352,7 +352,7 @@ private fun CardExpireDateField(
             imeAction = ImeAction.Done,
         ),
         keyboardActions = KeyboardActions(onDone = {
-            keyboardController?.hide()
+            keyboardController.hide()
         }),
         isError = state.cardExpireDateInputField.isError,
         assistiveText = state.cardExpireDateInputField.errorMessages?.let { AnnotatedString(it) },

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -25,9 +25,11 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -65,6 +67,7 @@ import tech.dojo.pay.uisdk.presentation.components.MerchantInfoWithSupportedNetw
 import tech.dojo.pay.uisdk.presentation.components.SingleButtonView
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
+import tech.dojo.pay.uisdk.presentation.components.rememberKeyboardController
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardCheckOutHeaderType
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.state.CardDetailsCheckoutState
@@ -82,21 +85,10 @@ internal fun CardDetailsCheckoutScreen(
     showDojoBrand: Boolean,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
-    val view = LocalView.current
-    val keyboardController = object : KeyboardController {
-        val imm = LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
-
-        override fun show() {
-            imm?.showSoftInput(view, 0)
-        }
-
-        override fun hide() {
-            imm?.hideSoftInputFromWindow(view.windowToken, 0)
-        }
-    }
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
-    var scrollToPosition by remember { mutableStateOf(0F) }
+    val keyboardController = rememberKeyboardController()
+    var scrollToPosition by remember { mutableFloatStateOf(0F) }
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         backgroundColor = DojoTheme.colors.primarySurfaceBackgroundColor,
@@ -213,7 +205,6 @@ internal fun CardDetailsCheckoutScreen(
         },
     )
 }
-
 @Composable
 private fun Loading(isVisible: Boolean) {
     if (isVisible) {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
@@ -1,7 +1,5 @@
 package tech.dojo.pay.uisdk.presentation.ui.result
 
-import android.content.Context
-import android.view.inputmethod.InputMethodManager
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
@@ -25,8 +23,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -42,9 +38,9 @@ import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooterModes
 import tech.dojo.pay.uisdk.presentation.components.DojoFullGroundButton
 import tech.dojo.pay.uisdk.presentation.components.DojoOutlinedButton
 import tech.dojo.pay.uisdk.presentation.components.DojoSpacer
-import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
+import tech.dojo.pay.uisdk.presentation.components.rememberKeyboardController
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.components.theme.bold
 import tech.dojo.pay.uisdk.presentation.ui.result.state.PaymentResultState
@@ -72,19 +68,7 @@ internal fun ShowResultSheetScreen(
         )
     val coroutineScope = rememberCoroutineScope()
     val state = viewModel.state.observeAsState().value ?: return
-    val view = LocalView.current
-    val keyboardController = object : KeyboardController {
-        val imm = LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
-
-        override fun show() {
-            imm?.showSoftInput(view, 0)
-        }
-
-        override fun hide() {
-            imm?.hideSoftInputFromWindow(view.windowToken, 0)
-        }
-    }
-
+    val keyboardController = rememberKeyboardController()
     LaunchedEffect(Unit) {
         keyboardController.hide()
         paymentResultSheetState.show()

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
@@ -1,5 +1,7 @@
 package tech.dojo.pay.uisdk.presentation.ui.result
 
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
@@ -24,7 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -40,6 +43,7 @@ import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooterModes
 import tech.dojo.pay.uisdk.presentation.components.DojoFullGroundButton
 import tech.dojo.pay.uisdk.presentation.components.DojoOutlinedButton
 import tech.dojo.pay.uisdk.presentation.components.DojoSpacer
+import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
@@ -47,8 +51,8 @@ import tech.dojo.pay.uisdk.presentation.components.theme.bold
 import tech.dojo.pay.uisdk.presentation.ui.result.state.PaymentResultState
 import tech.dojo.pay.uisdk.presentation.ui.result.viewmodel.PaymentResultViewModel
 
+@OptIn(ExperimentalMaterialApi::class)
 @Suppress("LongMethod")
-@OptIn(ExperimentalMaterialApi::class, ExperimentalComposeUiApi::class)
 @Composable
 internal fun ShowResultSheetScreen(
     windowSize: WindowSize,
@@ -69,11 +73,21 @@ internal fun ShowResultSheetScreen(
         )
     val coroutineScope = rememberCoroutineScope()
     val state = viewModel.state.observeAsState().value ?: return
+    val view = LocalView.current
+    val keyboardController = object : KeyboardController {
+        val imm = LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
 
-    val keyboardController = LocalSoftwareKeyboardController.current
+        override fun show() {
+            imm?.showSoftInput(view, 0)
+        }
+
+        override fun hide() {
+            imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
 
     LaunchedEffect(Unit) {
-        keyboardController?.hide()
+        keyboardController.hide()
         paymentResultSheetState.show()
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/BillingAddressSection.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/BillingAddressSection.kt
@@ -15,11 +15,9 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -32,19 +30,19 @@ import kotlinx.coroutines.CoroutineScope
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.components.CountrySelectorField
 import tech.dojo.pay.uisdk.presentation.components.InputFieldWithErrorMessage
+import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.autoScrollableInputFieldOnFocusChangeAndValidator
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.components.theme.medium
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.state.BillingAddressViewState
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.viewmodel.VirtualTerminalViewModel
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun BillingAddressSection(
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
     var parentPosition by remember { mutableStateOf(0f) }
@@ -106,14 +104,13 @@ private fun HeaderTitle() {
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun Address1Field(
     billingAddressViewState: BillingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -142,14 +139,13 @@ private fun Address1Field(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun Address2Field(
     billingAddressViewState: BillingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -185,14 +181,13 @@ private fun Address2Field(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CityField(
     billingAddressViewState: BillingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -222,14 +217,13 @@ private fun CityField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PostalCodeField(
     billingAddressViewState: BillingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/CardDetailsSection.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/CardDetailsSection.kt
@@ -19,11 +19,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.buildAnnotatedString
@@ -40,6 +38,7 @@ import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooter
 import tech.dojo.pay.uisdk.presentation.components.DojoBrandFooterModes
 import tech.dojo.pay.uisdk.presentation.components.DojoSpacer
 import tech.dojo.pay.uisdk.presentation.components.InputFieldWithErrorMessage
+import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.SupportedPaymentMethods
 import tech.dojo.pay.uisdk.presentation.components.autoScrollableInputFieldOnFocusChangeAndValidator
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
@@ -47,14 +46,13 @@ import tech.dojo.pay.uisdk.presentation.components.theme.medium
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.state.CardDetailsViewState
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.viewmodel.VirtualTerminalViewModel
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun CardDetailsSection(
     viewModel: VirtualTerminalViewModel,
     isDarkModeEnabled: Boolean,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
     showDojoBrand: Boolean,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
@@ -148,14 +146,13 @@ private fun HeaderTitle() {
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CardHolderInputField(
     cardDetailsViewState: CardDetailsViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -181,7 +178,6 @@ private fun CardHolderInputField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CardNumberInputField(
     cardDetailsViewState: CardDetailsViewState,
@@ -189,7 +185,7 @@ private fun CardNumberInputField(
     isDarkModeEnabled: Boolean,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -223,14 +219,13 @@ private fun CardNumberInputField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CardExpireDateField(
     cardDetailsViewState: CardDetailsViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -261,14 +256,13 @@ private fun CardExpireDateField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CvvField(
     cardDetailsViewState: CardDetailsViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -300,14 +294,13 @@ private fun CvvField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun EmailInputField(
     cardDetailsViewState: CardDetailsViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/ShippingAddressSection.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/ShippingAddressSection.kt
@@ -15,11 +15,9 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
-import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -34,19 +32,19 @@ import tech.dojo.pay.uisdk.presentation.components.CheckBoxItem
 import tech.dojo.pay.uisdk.presentation.components.CountrySelectorField
 import tech.dojo.pay.uisdk.presentation.components.DescriptionField
 import tech.dojo.pay.uisdk.presentation.components.InputFieldWithErrorMessage
+import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.autoScrollableInputFieldOnFocusChangeAndValidator
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.components.theme.medium
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.state.ShippingAddressViewState
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.viewmodel.VirtualTerminalViewModel
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun ShippingAddressSection(
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
     if (state.shippingAddressSection?.isVisible == true) {
@@ -127,14 +125,13 @@ private fun HeaderTitle() {
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun NameField(
     shippingAddressSection: ShippingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -158,14 +155,13 @@ private fun NameField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun Address1Field(
     shippingAddressSection: ShippingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -194,14 +190,13 @@ private fun Address1Field(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun Address2Field(
     shippingAddressSection: ShippingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -237,14 +232,13 @@ private fun Address2Field(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun CityField(
     shippingAddressSection: ShippingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }
@@ -270,14 +264,13 @@ private fun CityField(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun PostalCodeField(
     shippingAddressSection: ShippingAddressViewState,
     viewModel: VirtualTerminalViewModel,
     coroutineScope: CoroutineScope,
     scrollState: ScrollState,
-    keyboardController: SoftwareKeyboardController?,
+    keyboardController: KeyboardController?,
     parentPosition: Float,
 ) {
     val hasBeenFocused by remember { mutableStateOf(false) }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/VirtualTerminalCheckOutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/VirtualTerminalCheckOutScreen.kt
@@ -1,7 +1,5 @@
 package tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout
 
-import android.content.Context
-import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -22,19 +20,17 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.components.AmountWithMerchantIInfoHeader
 import tech.dojo.pay.uisdk.presentation.components.AppBarIcon
 import tech.dojo.pay.uisdk.presentation.components.DojoAppBar
-import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.SingleButtonView
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
+import tech.dojo.pay.uisdk.presentation.components.rememberKeyboardController
 import tech.dojo.pay.uisdk.presentation.components.theme.DojoTheme
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.state.VirtualTerminalViewState
 import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.viewmodel.VirtualTerminalViewModel
@@ -51,16 +47,7 @@ internal fun VirtualTerminalCheckOutScreen(
     showDojoBrand: Boolean,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
-    val view = LocalView.current
-    val keyboardController = object : KeyboardController {
-        val imm = LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
-        override fun show() {
-            imm?.showSoftInput(view, 0)
-        }
-        override fun hide() {
-            imm?.hideSoftInputFromWindow(view.windowToken, 0)
-        }
-    }
+    val keyboardController = rememberKeyboardController()
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
     Scaffold(
@@ -165,9 +152,15 @@ private fun PayButton(
     val focusManager = LocalFocusManager.current
     SingleButtonView(
         scrollState = scrollState,
-        text =
-        String
-            .format(Locale.getDefault(), "%s %s %s", stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_button_pay), state.paymentDetailsSection?.amountCurrency, state.paymentDetailsSection?.totalAmount),
+        text = String.format(
+            Locale.getDefault(),
+            "%s %s %s",
+            stringResource(
+                id = R.string.dojo_ui_sdk_card_details_checkout_button_pay,
+            ),
+            state.paymentDetailsSection?.amountCurrency,
+            state.paymentDetailsSection?.totalAmount,
+        ),
         isLoading = state.payButtonSection?.isLoading ?: false,
         enabled = state.payButtonSection?.isEnabled ?: false,
     ) {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/VirtualTerminalCheckOutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/VirtualTerminalCheckOutScreen.kt
@@ -1,5 +1,7 @@
 package tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout
 
+import android.content.Context
+import android.view.inputmethod.InputMethodManager
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,16 +21,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.presentation.components.AmountWithMerchantIInfoHeader
 import tech.dojo.pay.uisdk.presentation.components.AppBarIcon
 import tech.dojo.pay.uisdk.presentation.components.DojoAppBar
+import tech.dojo.pay.uisdk.presentation.components.KeyboardController
 import tech.dojo.pay.uisdk.presentation.components.SingleButtonView
 import tech.dojo.pay.uisdk.presentation.components.TitleGravity
 import tech.dojo.pay.uisdk.presentation.components.WindowSize
@@ -38,7 +41,6 @@ import tech.dojo.pay.uisdk.presentation.ui.virtualterminalcheckout.viewmodel.Vir
 import java.util.Locale
 
 @Suppress("LongMethod")
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun VirtualTerminalCheckOutScreen(
     windowSize: WindowSize,
@@ -49,7 +51,16 @@ internal fun VirtualTerminalCheckOutScreen(
     showDojoBrand: Boolean,
 ) {
     val state = viewModel.state.observeAsState().value ?: return
-    val keyboardController = LocalSoftwareKeyboardController.current
+    val view = LocalView.current
+    val keyboardController = object : KeyboardController {
+        val imm = LocalContext.current.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        override fun show() {
+            imm?.showSoftInput(view, 0)
+        }
+        override fun hide() {
+            imm?.hideSoftInputFromWindow(view.windowToken, 0)
+        }
+    }
     val coroutineScope = rememberCoroutineScope()
     val scrollState = rememberScrollState()
     Scaffold(

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/viewmodel/VirtualTerminalViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/virtualterminalcheckout/viewmodel/VirtualTerminalViewModel.kt
@@ -100,11 +100,11 @@ internal class VirtualTerminalViewModel(
             currentState = currentState.copy(
                 shippingAddressSection = currentState
                     .shippingAddressSection?.updateAddressName(
-                        virtualTerminalValidator.validateInputFieldIsNotEmpty(
-                            finalValue,
-                            InputFieldType.NAME,
-                        ),
+                    virtualTerminalValidator.validateInputFieldIsNotEmpty(
+                        finalValue,
+                        InputFieldType.NAME,
                     ),
+                ),
             )
             pushStateToUi(currentState)
         }
@@ -352,11 +352,11 @@ internal class VirtualTerminalViewModel(
             currentState = currentState.copy(
                 cardDetailsSection = currentState
                     .cardDetailsSection?.updateCardHolderInputField(
-                        virtualTerminalValidator.validateInputFieldIsNotEmpty(
-                            finalValue,
-                            InputFieldType.CARD_HOLDER_NAME,
-                        ),
+                    virtualTerminalValidator.validateInputFieldIsNotEmpty(
+                        finalValue,
+                        InputFieldType.CARD_HOLDER_NAME,
                     ),
+                ),
             )
             pushStateToUi(currentState)
         }
@@ -378,8 +378,8 @@ internal class VirtualTerminalViewModel(
             currentState = currentState.copy(
                 cardDetailsSection = currentState
                     .cardDetailsSection?.updateCardNumberInputField(
-                        virtualTerminalValidator.validateCardNumberInputField(finalValue),
-                    ),
+                    virtualTerminalValidator.validateCardNumberInputField(finalValue),
+                ),
             )
             pushStateToUi(currentState)
         }
@@ -401,8 +401,8 @@ internal class VirtualTerminalViewModel(
             currentState = currentState.copy(
                 cardDetailsSection = currentState
                     .cardDetailsSection?.updateCvvInputFieldState(
-                        virtualTerminalValidator.validateCVVInputField(finalValue),
-                    ),
+                    virtualTerminalValidator.validateCVVInputField(finalValue),
+                ),
             )
             pushStateToUi(currentState)
         }
@@ -424,8 +424,8 @@ internal class VirtualTerminalViewModel(
             currentState = currentState.copy(
                 cardDetailsSection = currentState
                     .cardDetailsSection?.updateCardExpireDateInputField(
-                        virtualTerminalValidator.validateExpireDateInputField(finalValue),
-                    ),
+                    virtualTerminalValidator.validateExpireDateInputField(finalValue),
+                ),
             )
             pushStateToUi(currentState)
         }
@@ -447,8 +447,8 @@ internal class VirtualTerminalViewModel(
             currentState = currentState.copy(
                 cardDetailsSection = currentState
                     .cardDetailsSection?.updateEmailInputField(
-                        virtualTerminalValidator.validateEmailInputField(finalValue),
-                    ),
+                    virtualTerminalValidator.validateEmailInputField(finalValue),
+                ),
             )
             pushStateToUi(currentState)
         }
@@ -464,7 +464,7 @@ internal class VirtualTerminalViewModel(
 
     fun onPayClicked() {
         showLoadingOnActionButton()
-        viewModelScope.launch() {
+        viewModelScope.launch {
             makeVTPaymentUseCase
                 .makeVTPayment(
                     params = MakeVTPaymentParams(


### PR DESCRIPTION
## what 
- make SDK computable with compose `1.6`+ and avoid crash because of the `LocalSoftwareKeyboardController `

## How 
- move a way from the `LocalSoftwareKeyboardController` across  the SDK and USE  classic  `InputMethodManager` way to deal with keyBoard   