### PR TITLE
Task/pppp-856 Additonal legal text

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -32,6 +32,10 @@ class UiSdkSampleActivity : AppCompatActivity() {
 
         uiSdkSampleBinding.startPaymentFlow.setOnClickListener {
             DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = false)
+            if (uiSdkSampleBinding.checkboxAdditonalLegalText.isChecked) {
+                DojoSDKDropInUI.dojoThemeSettings?.additionalLegalText =
+                    "Dojo is a trading name of Paymentsense Limited. Copyright ©2024 Paymentsense Limited. All rights reserved. Paymentsense Limited is authorised and regulated by the Financial Conduct Authority (FCA FRN 738728) and under the Electronic Money Regulations 2011 (FCA FRN 900925) for the issuing of electronic money and provision of payment services. Our company number is 06730690 and our registered office address is The Brunel Building, 2 Canalside Walk, London W2 1DG"
+            }
             dojoPayUI.startPaymentFlow(
                 DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),
             )

--- a/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/UiSdkSampleActivity.kt
@@ -32,12 +32,15 @@ class UiSdkSampleActivity : AppCompatActivity() {
 
         uiSdkSampleBinding.startPaymentFlow.setOnClickListener {
             DojoSDKDropInUI.dojoThemeSettings = DojoThemeSettings(forceLightMode = false)
+            secret = if (secret.isEmpty()) uiSdkSampleBinding.clientSecret.text.toString() else ""
+            print(secret)
             if (uiSdkSampleBinding.checkboxAdditonalLegalText.isChecked) {
                 DojoSDKDropInUI.dojoThemeSettings?.additionalLegalText =
                     "Dojo is a trading name of Paymentsense Limited. Copyright ©2024 Paymentsense Limited. All rights reserved. Paymentsense Limited is authorised and regulated by the Financial Conduct Authority (FCA FRN 738728) and under the Electronic Money Regulations 2011 (FCA FRN 900925) for the issuing of electronic money and provision of payment services. Our company number is 06730690 and our registered office address is The Brunel Building, 2 Canalside Walk, London W2 1DG"
             }
             dojoPayUI.startPaymentFlow(
-                DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString()),
+                DojoPaymentFlowParams(uiSdkSampleBinding.token.text.toString(),
+                    secret),
             )
         }
         uiSdkSampleBinding.startPaymentFlowWithVT.setOnClickListener {

--- a/sample/src/main/res/layout/activity_ui_sdk_sample.xml
+++ b/sample/src/main/res/layout/activity_ui_sdk_sample.xml
@@ -129,6 +129,28 @@
             android:layout_height="wrap_content"
             android:text="" />
 
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/user_client_secret_container"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="100dp"
+        android:layout_margin="16dp"
+        android:hint="client secret"
+        app:layout_constraintBottom_toTopOf="@+id/startPaymentFlow"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/user_token_text_container">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/client_secret"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="" />
+
+
     </com.google.android.material.textfield.TextInputLayout>
 
     <Button

--- a/sample/src/main/res/layout/activity_ui_sdk_sample.xml
+++ b/sample/src/main/res/layout/activity_ui_sdk_sample.xml
@@ -50,18 +50,28 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="16dp"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="5dp"
         android:checked="true"
         android:text="Sandbox"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatCheckBox
+        android:id="@+id/checkboxAdditonalLegalText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:checked="false"
+        android:text="Show additional legal text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/checkboxSandbox" />
 
     <Button
         android:id="@+id/btnGenerateToken"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="88dp"
-        android:layout_marginTop="24dp"
+        android:layout_marginTop="5dp"
         android:text="Generate token"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.698"
@@ -74,7 +84,7 @@
         android:layout_width="match_parent"
         android:layout_height="100dp"
         android:layout_marginLeft="16dp"
-        android:layout_marginTop="16dp"
+        android:layout_marginTop="50dp"
         android:layout_marginRight="16dp"
         android:hint="Token"
         app:layout_constraintEnd_toEndOf="parent"

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
@@ -10,7 +10,8 @@ data class DojoThemeSettings @JvmOverloads constructor(
     val darkColorPalette: DarkColorPalette = DarkColorPalette(),
     val forceLightMode: Boolean = false,
     val showBranding: Boolean = true,
-    val analyticsExcludedFieldsIdentifier: String = ""
+    val analyticsExcludedFieldsIdentifier: String = "",
+    var additionalLegalText: String = ""
 ) : Serializable
 
 @Keep

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -86,6 +86,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 val forceLightMode = DojoSDKDropInUI.dojoThemeSettings?.forceLightMode ?: false
                 val isDarkModeEnabled = isSystemInDarkTheme() && !forceLightMode
                 val showDojoBrand = DojoSDKDropInUI.dojoThemeSettings?.showBranding ?: false
+                val additionalLegalText = DojoSDKDropInUI.dojoThemeSettings?.additionalLegalText ?: ""
                 val customColorPalette =
                     paymentFlowViewModel.getCustomColorPalette(isDarkModeEnabled)
                 val windowSize = rememberWindowSize()
@@ -107,6 +108,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                             isDarkModeEnabled,
                             windowSize,
                             showDojoBrand,
+                            additionalLegalText
                         )
                     }
                 }
@@ -225,6 +227,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         isDarkModeEnabled: Boolean,
         windowSize: WindowSize,
         showDojoBrand: Boolean,
+        additionalLegalText: String
     ) {
         NavHost(
             navController = navController,
@@ -234,6 +237,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 windowSize = windowSize,
                 viewModel = paymentFlowViewModel,
                 showDojoBrand = showDojoBrand,
+                additionalLegalText = additionalLegalText
             )
             managePaymentMethodsScreen(
                 isDarkModeEnabled = isDarkModeEnabled,
@@ -266,6 +270,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         windowSize: WindowSize,
         viewModel: PaymentFlowViewModel,
         showDojoBrand: Boolean,
+        additionalLegalText: String
     ) {
         composable(
             route = PaymentFlowScreens.PaymentMethodCheckout.route,
@@ -292,6 +297,7 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
                 onManagePaymentClicked = viewModel::navigateToManagePaymentMethods,
                 onPayByCard = viewModel::navigateToCardDetailsCheckoutScreen,
                 showDojoBrand = showDojoBrand,
+                additionalLegalText = additionalLegalText
             )
         }
     }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/paymentmethodcheckout/PaymentMethodsSheet.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/paymentmethodcheckout/PaymentMethodsSheet.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetState
 import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -28,6 +29,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -60,6 +62,7 @@ internal fun PaymentMethodsCheckOutScreen(
     onManagePaymentClicked: () -> Unit,
     onPayByCard: () -> Unit,
     showDojoBrand: Boolean,
+    additionalLegalText: String
 ) {
     val paymentMethodsSheetState =
         rememberModalBottomSheetState(
@@ -77,7 +80,9 @@ internal fun PaymentMethodsCheckOutScreen(
         viewModel.onSavedPaymentMethodChanged(currentSelectedMethod)
     }
     DojoBottomSheet(
-        modifier = Modifier.fillMaxSize().animateContentSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .animateContentSize(),
         sheetState = paymentMethodsSheetState,
         sheetBackgroundColor = DojoTheme.colors.primarySurfaceBackgroundColor,
         sheetContent = {
@@ -93,6 +98,7 @@ internal fun PaymentMethodsCheckOutScreen(
                 viewModel::onCvvValueChanged,
                 windowSize,
                 showDojoBrand,
+                additionalLegalText
             )
         },
     ) {
@@ -116,6 +122,7 @@ private fun BottomSheetItems(
     onCvvChanged: (String) -> Unit,
     windowSize: WindowSize,
     showDojoBrand: Boolean,
+    additionalLegalText: String,
 ) {
     AppBar(coroutineScope, sheetState, onAppBarIconClicked)
     if (contentState.isBottomSheetLoading) {
@@ -141,17 +148,18 @@ private fun BottomSheetItems(
                 )
                 PaymentMethodsButton(contentState, onPayByCard, onManagePaymentClicked)
                 PayAmountButton(contentState, onPayAmount)
-                FooterItem(showDojoBrand)
+                FooterItem(showDojoBrand, additionalLegalText)
             }
         }
     }
 }
 
 @Composable
-private fun FooterItem(showDojoBrand: Boolean) {
+private fun FooterItem(showDojoBrand: Boolean, additionalLegalText: String) {
+    val bottomPadding = if (additionalLegalText.isNotEmpty()) 8 else 24
     if (showDojoBrand) {
         DojoBrandFooter(
-            modifier = Modifier.padding(24.dp, 8.dp, 16.dp, 24.dp),
+            modifier = Modifier.padding(24.dp, 8.dp, 16.dp, bottomPadding.dp),
             mode = DojoBrandFooterModes.DOJO_BRAND_ONLY,
         )
     } else {
@@ -159,6 +167,27 @@ private fun FooterItem(showDojoBrand: Boolean) {
             modifier = Modifier.padding(24.dp, 8.dp, 16.dp, 8.dp),
             mode = DojoBrandFooterModes.NONE,
         )
+    }
+
+    if (additionalLegalText.isNotEmpty()) {
+        Text(text = additionalLegalText,
+            style = DojoTheme.typography.subtitle2,
+            color = DojoTheme.colors.secondaryLabelTextColor,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 16.dp)
+        )
+    }
+}
+
+@Composable
+private fun AdditionalLegalText(text: String) {
+    if (text.isNotEmpty()) {
+        Text(text = text,
+            style = DojoTheme.typography.subtitle2,
+            color = DojoTheme.colors.secondaryLabelTextColor,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(8.dp, 0.dp, 8.dp, 16.dp)
+            )
     }
 }
 


### PR DESCRIPTION
Add ability to pass additional legal text that would be visible at the footer on the first checkout page. 

https://github.com/dojo-engineering/android-dojo-pay-sdk/assets/91316159/11313699-ad99-424d-acf5-d3c26c4599d4

