### PR TITLE
MPP-1655: allow custom copy on card payment.

### DIFF
--- a/sample/src/main/java/tech/dojo/pay/sdksample/ExampleJava.java
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/ExampleJava.java
@@ -42,7 +42,7 @@ public class ExampleJava extends AppCompatActivity {
         Button button= findViewById(R.id.startPaymentJava);
         button.setOnClickListener(v -> dojoPaymentFlowHandler.startPaymentFlow(
                 new DojoPaymentFlowParams(
-                        "pi_sandbox_RBMHTJ4fIkmSppDILZVCGw",
+                        "", // payment-intent-id
                         "" , // add this if you supports saved card else pass null
                         dojoGPayConfig // add this if you support google pay else pass null
                 )

--- a/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
@@ -33,7 +33,7 @@ class ExampleKotlin : AppCompatActivity() {
         button.setOnClickListener {
             dojoHandler.startPaymentFlow(
                 DojoPaymentFlowParams(
-                    paymentId = "pi_sandbox_mDvzElFkoU2QH440cwoOEg",
+                    paymentId = "pi_sandbox_UddFbS3y50qsebyYukRU7g",
                     // add this if you supports saved card
                     clientSecret = "",
                     // add this if you supports google pay

--- a/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
@@ -17,6 +17,16 @@ class ExampleKotlin : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sample_ui_sdk)
 
+        DojoSDKDropInUI.dojoThemeSettings?.customCardDetailsNavigationTitle = "Custom title"
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleFail = "Custom title fail"
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextFail = "Custom title main"
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextFail = "Custom additional text"
+
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleSuccess = "Custom title success"
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextSuccess = "Custom title main s"
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextSuccess = "Custom title main s"
+        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenOrderIdText = "Custom order Id"
+
         val button = findViewById<Button>(R.id.startPayment)
         button.setOnClickListener {
             dojoHandler.startPaymentFlow(

--- a/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
@@ -17,15 +17,17 @@ class ExampleKotlin : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sample_ui_sdk)
 
-        DojoSDKDropInUI.dojoThemeSettings?.customCardDetailsNavigationTitle = "Custom title"
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleFail = "Custom title fail"
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextFail = "Custom title main"
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextFail = "Custom additional text"
+//        DojoSDKDropInUI.dojoThemeSettings?.customCardDetailsNavigationTitle = "Custom title"
 
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleSuccess = "Custom title success"
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextSuccess = "Custom title main s"
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextSuccess = "Custom title main s"
-        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenOrderIdText = "Custom order Id"
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleFail = "Custom title fail"
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextFail = "Custom title main"
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextFail = "Custom additional text"
+//
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleSuccess = "Custom title success"
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextSuccess = "Custom title main s"
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextSuccess = "Custom title main s"
+
+//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenOrderIdText = "Custom order Id"
 
         val button = findViewById<Button>(R.id.startPayment)
         button.setOnClickListener {

--- a/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/ExampleKotlin.kt
@@ -17,23 +17,12 @@ class ExampleKotlin : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_sample_ui_sdk)
 
-//        DojoSDKDropInUI.dojoThemeSettings?.customCardDetailsNavigationTitle = "Custom title"
-
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleFail = "Custom title fail"
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextFail = "Custom title main"
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextFail = "Custom additional text"
-//
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenTitleSuccess = "Custom title success"
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenMainTextSuccess = "Custom title main s"
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenAdditionalTextSuccess = "Custom title main s"
-
-//        DojoSDKDropInUI.dojoThemeSettings?.customResultScreenOrderIdText = "Custom order Id"
-
         val button = findViewById<Button>(R.id.startPayment)
         button.setOnClickListener {
             dojoHandler.startPaymentFlow(
                 DojoPaymentFlowParams(
-                    paymentId = "pi_sandbox_UddFbS3y50qsebyYukRU7g",
+                    // payment-intent-id
+                    paymentId = "",
                     // add this if you supports saved card
                     clientSecret = "",
                     // add this if you supports google pay

--- a/sample/src/main/java/tech/dojo/pay/sdksample/SampleActivity.kt
+++ b/sample/src/main/java/tech/dojo/pay/sdksample/SampleActivity.kt
@@ -30,16 +30,16 @@ import tech.dojo.pay.uisdk.DojoSDKDropInUI
 
 class SampleActivity : ComponentActivity() {
 
-    private val DarkColorPalette = darkColors()
+    private val darkColorPalette = darkColors()
 
-    private val LightColorPalette = lightColors()
+    private val lightColorPalette = lightColors()
 
     @Composable
     fun Theme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
         val colors = if (darkTheme) {
-            DarkColorPalette
+            darkColorPalette
         } else {
-            LightColorPalette
+            lightColorPalette
         }
 
         MaterialTheme(colors = colors, content = content)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/core/Extension.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/core/Extension.kt
@@ -2,7 +2,11 @@ package tech.dojo.pay.uisdk.core
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
 import androidx.activity.ComponentActivity
+import java.io.Serializable
 
 inline fun <reified Activity : ComponentActivity> Context.getActivity(): Activity? {
     return when (this) {
@@ -16,4 +20,14 @@ inline fun <reified Activity : ComponentActivity> Context.getActivity(): Activit
             null
         }
     }
+}
+
+inline fun <reified T : Serializable> Bundle.serializableCompat(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializable(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getSerializable(key) as? T
+}
+
+inline fun <reified T : Serializable> Intent.serializableCompat(key: String): T? = when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> getSerializableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getSerializableExtra(key) as? T
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/entities/DojoThemeSettings.kt
@@ -11,7 +11,15 @@ data class DojoThemeSettings @JvmOverloads constructor(
     val forceLightMode: Boolean = false,
     val showBranding: Boolean = true,
     val analyticsExcludedFieldsIdentifier: String = "",
-    var additionalLegalText: String = ""
+    var additionalLegalText: String = "",
+    var customCardDetailsNavigationTitle: String? = null,
+    var customResultScreenTitleSuccess: String? = null,
+    var customResultScreenTitleFail: String? = null,
+    var customResultScreenOrderIdText: String? = null,
+    var customResultScreenMainTextSuccess: String? = null,
+    var customResultScreenMainTextFail: String? = null,
+    var customResultScreenAdditionalTextSuccess: String? = null,
+    var customResultScreenAdditionalTextFail: String? = null,
 ) : Serializable
 
 @Keep

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/CustomStringProvider.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/CustomStringProvider.kt
@@ -1,0 +1,12 @@
+package tech.dojo.pay.uisdk.presentation.ui
+
+internal data class CustomStringProvider(
+    val cardDetailsNavigationTitle: String? = null,
+    val resultScreenTitleSuccess: String? = null,
+    val resultScreenTitleFail: String? = null,
+    val resultScreenOrderIdText: String? = null,
+    val resultScreenMainTextSuccess: String? = null,
+    val resultScreenMainTextFail: String? = null,
+    val resultScreenAdditionalTextSuccess: String? = null,
+    val resultScreenAdditionalTextFail: String? = null,
+)

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/CardDetailsCheckoutScreen.kt
@@ -561,11 +561,10 @@ private fun HeaderItem(state: CardDetailsCheckoutState) {
 private fun AppBarItem(
     onBackClicked: () -> Unit,
     onCloseClicked: () -> Unit,
-    toolbarTitle: String?,
+    toolbarTitle: String,
 ) {
     DojoAppBar(
-        title = toolbarTitle
-            ?: stringResource(id = R.string.dojo_ui_sdk_card_details_checkout_title),
+        title = toolbarTitle,
         titleGravity = TitleGravity.LEFT,
         navigationIcon = AppBarIcon.back(DojoTheme.colors.headerButtonTintColor) { onBackClicked() },
         actionIcon = AppBarIcon.close(DojoTheme.colors.headerButtonTintColor) { onCloseClicked() },

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModel.kt
@@ -15,6 +15,7 @@ import tech.dojo.pay.uisdk.domain.ObservePaymentIntent
 import tech.dojo.pay.uisdk.domain.ObservePaymentStatus
 import tech.dojo.pay.uisdk.domain.entities.MakeCardPaymentParams
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentResult
+import tech.dojo.pay.uisdk.presentation.ui.CustomStringProvider
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.CardCheckOutFullCardPaymentPayloadMapper
@@ -40,6 +41,7 @@ internal class CardDetailsCheckoutViewModel(
     private val isStartDestination: Boolean,
     private val makeCardPaymentUseCase: MakeCardPaymentUseCase,
     private val navigateToCardResult: (dojoPaymentResult: DojoPaymentResult) -> Unit,
+    private val customStringProvider: CustomStringProvider,
 ) : ViewModel() {
     private lateinit var paymentIntentId: String
     private var currentState: CardDetailsCheckoutState
@@ -361,7 +363,7 @@ internal class CardDetailsCheckoutViewModel(
     private fun getToolBarTitle() = if (isStartDestination) {
         stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title_setup_intent)
     } else {
-        stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)
+        customStringProvider.cardDetailsNavigationTitle ?: stringProvider.getString(R.string.dojo_ui_sdk_card_details_checkout_title)
     }
 
     private fun getCheckBoxMessage(paymentIntentResult: PaymentIntentResult.Success) =

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelFactory.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelProvider
 import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.sdk.card.presentation.card.handler.DojoCardPaymentHandler
 import tech.dojo.pay.uisdk.core.StringProvider
+import tech.dojo.pay.uisdk.core.serializableCompat
 import tech.dojo.pay.uisdk.data.paymentintent.RefreshPaymentIntentRepository
 import tech.dojo.pay.uisdk.data.supportedcountries.SupportedCountriesDataSource
 import tech.dojo.pay.uisdk.data.supportedcountries.SupportedCountriesRepository
@@ -21,20 +22,22 @@ import tech.dojo.pay.uisdk.entities.DojoPaymentFlowParams
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
 import tech.dojo.pay.uisdk.presentation.PaymentFlowViewModelFactory
 import tech.dojo.pay.uisdk.presentation.contract.DojoPaymentFlowHandlerResultContract
+import tech.dojo.pay.uisdk.presentation.ui.CustomStringProvider
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.CardCheckOutFullCardPaymentPayloadMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.SupportedCountriesViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.validator.CardCheckoutScreenValidator
 
-class CardDetailsCheckoutViewModelFactory(
+internal class CardDetailsCheckoutViewModelFactory(
     private val dojoCardPaymentHandler: DojoCardPaymentHandler,
     private val isDarkModeEnabled: Boolean,
     private val context: Context,
     private val isStartDestination: Boolean,
     private val arguments: Bundle?,
+    private val customStringProvider: CustomStringProvider,
     private val navigateToCardResult: (dojoPaymentResult: DojoPaymentResult) -> Unit,
 ) : ViewModelProvider.Factory {
-    @Suppress("UNCHECKED_CAST")
+
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val observePaymentIntent =
             ObservePaymentIntent(PaymentFlowViewModelFactory.paymentIntentRepository)
@@ -56,7 +59,7 @@ class CardDetailsCheckoutViewModelFactory(
         val fullCardPaymentPayloadMapper = CardCheckOutFullCardPaymentPayloadMapper()
         val stringProvider = StringProvider(context)
         val paymentType =
-            (arguments?.getSerializable(DojoPaymentFlowHandlerResultContract.KEY_PARAMS) as? DojoPaymentFlowParams)
+            arguments?.serializableCompat<DojoPaymentFlowParams>(DojoPaymentFlowHandlerResultContract.KEY_PARAMS)
                 ?.paymentType ?: DojoPaymentType.PAYMENT_CARD
         val refreshPaymentIntentRepository = RefreshPaymentIntentRepository()
 
@@ -73,6 +76,7 @@ class CardDetailsCheckoutViewModelFactory(
             refreshPaymentIntentUseCase,
         )
 
+        @Suppress("UNCHECKED_CAST")
         return CardDetailsCheckoutViewModel(
             observePaymentIntent,
             dojoCardPaymentHandler,
@@ -86,6 +90,7 @@ class CardDetailsCheckoutViewModelFactory(
             isStartDestination,
             makeCardPaymentUseCase,
             navigateToCardResult,
+            customStringProvider
         ) as T
     }
 }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/PaymentResultScreen.kt
@@ -187,6 +187,15 @@ private fun SuccessfulResult(
             color = DojoTheme.colors.primaryLabelTextColor,
             modifier = Modifier.padding(top = 16.dp),
         )
+        state.description.takeIf { it.isNotEmpty() }?.let {
+            Text(
+                text = state.description,
+                style = DojoTheme.typography.subtitle2,
+                textAlign = TextAlign.Center,
+                color = DojoTheme.colors.primaryLabelTextColor,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+        }
 
         DojoSpacer(height = 32.dp)
         DojoFullGroundButton(
@@ -249,9 +258,19 @@ private fun FailedResult(
             modifier = Modifier.padding(top = 16.dp),
         )
 
+        state.orderInfo?.let {
+            Text(
+                text = it,
+                style = DojoTheme.typography.subtitle1,
+                color = DojoTheme.colors.secondaryLabelTextColor,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+        }
+
         Text(
             text = state.details,
-            style = DojoTheme.typography.subtitle1,
+            style = DojoTheme.typography.subtitle2,
             color = DojoTheme.colors.secondaryLabelTextColor,
             textAlign = TextAlign.Center,
             modifier = Modifier.padding(top = 16.dp),

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapper.kt
@@ -4,6 +4,7 @@ import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.core.StringProvider
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
+import tech.dojo.pay.uisdk.presentation.ui.CustomStringProvider
 import tech.dojo.pay.uisdk.presentation.ui.result.state.PaymentResultState
 import java.util.Locale
 
@@ -11,6 +12,7 @@ internal class PaymentResultViewEntityMapper(
     private val stringProvider: StringProvider,
     private val paymentType: DojoPaymentType,
     private val isDarkModeEnabled: Boolean,
+    private val customStringProvider: CustomStringProvider
 ) {
     fun mapTpResultState(result: DojoPaymentResult) =
         if (result == DojoPaymentResult.SUCCESSFUL) {
@@ -19,21 +21,21 @@ internal class PaymentResultViewEntityMapper(
             buildFailedResult()
         }
 
-    fun mapToOrderIdField(orderId: String): String {
-        return String.format(
+    fun mapToOrderIdField(orderId: String): String =
+     customStringProvider.resultScreenOrderIdText ?: String.format(
             Locale.getDefault(),
             "%s %s",
             stringProvider.getString(R.string.dojo_ui_sdk_order_info),
             orderId,
         )
-    }
+
 
     private fun buildSuccessfulResult() = PaymentResultState.SuccessfulResult(
         appBarTitle = getSuccessfulAppBarTitle(),
         imageId = R.drawable.ic_success_circle,
         status = getSuccessfulStatusTitle(),
         orderInfo = "",
-        description = "",
+        description = getSuccessDetails(),
     )
 
     private fun buildFailedResult() = PaymentResultState.FailedResult(
@@ -47,44 +49,46 @@ internal class PaymentResultViewEntityMapper(
     private fun getFailedDetails() =
         when (paymentType) {
             DojoPaymentType.SETUP_INTENT -> stringProvider.getString(R.string.dojo_ui_sdk_payment_result_main_title_setup_intent_fail)
-            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL -> stringProvider.getString(
-                R.string.dojo_ui_sdk_payment_result_failed_description,
-            )
+            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
+                customStringProvider.resultScreenAdditionalTextFail ?: stringProvider.getString(R.string.dojo_ui_sdk_payment_result_failed_description)
+        }
+
+    private fun getSuccessDetails() =
+        when (paymentType) {
+            DojoPaymentType.SETUP_INTENT -> ""
+            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
+                customStringProvider.resultScreenAdditionalTextSuccess.orEmpty()
         }
 
     private fun getSuccessfulStatusTitle(): String {
         return when (paymentType) {
             DojoPaymentType.SETUP_INTENT -> stringProvider.getString(R.string.dojo_ui_sdk_payment_result_main_title_setup_intent_success)
-            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL -> stringProvider.getString(
-                R.string.dojo_ui_sdk_payment_result_title_success,
-            )
+            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
+                customStringProvider.resultScreenMainTextSuccess ?: stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_success)
         }
     }
 
     private fun getFailedStatusTitle(): String {
         return when (paymentType) {
             DojoPaymentType.SETUP_INTENT -> stringProvider.getString(R.string.dojo_ui_sdk_payment_result_main_message_setup_intent_fail)
-            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL -> stringProvider.getString(
-                R.string.dojo_ui_sdk_payment_result_title_fail,
-            )
+            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
+                customStringProvider.resultScreenMainTextFail ?: stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_fail)
         }
     }
 
     private fun getSuccessfulAppBarTitle(): String {
         return when (paymentType) {
             DojoPaymentType.SETUP_INTENT -> stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_setup_intent_success)
-            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL -> stringProvider.getString(
-                R.string.dojo_ui_sdk_payment_result_title_success,
-            )
+            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
+                customStringProvider.resultScreenTitleSuccess ?: stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_success)
         }
     }
 
     private fun getFailedAppBarTitle(): String {
         return when (paymentType) {
             DojoPaymentType.SETUP_INTENT -> stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_setup_intent_fail)
-            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL -> stringProvider.getString(
-                R.string.dojo_ui_sdk_payment_result_title_fail,
-            )
+            DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
+                customStringProvider.resultScreenTitleFail ?: stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_fail)
         }
     }
 

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapper.kt
@@ -22,13 +22,12 @@ internal class PaymentResultViewEntityMapper(
         }
 
     fun mapToOrderIdField(orderId: String): String =
-     customStringProvider.resultScreenOrderIdText ?: String.format(
+        customStringProvider.resultScreenOrderIdText ?: String.format(
             Locale.getDefault(),
             "%s %s",
             stringProvider.getString(R.string.dojo_ui_sdk_order_info),
             orderId,
         )
-
 
     private fun buildSuccessfulResult() = PaymentResultState.SuccessfulResult(
         appBarTitle = getSuccessfulAppBarTitle(),

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapper.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapper.kt
@@ -43,6 +43,7 @@ internal class PaymentResultViewEntityMapper(
         shouldNavigateToPreviousScreen = false,
         status = getFailedStatusTitle(),
         details = getFailedDetails(),
+        orderInfo = getFailedOrderInfo(),
     )
 
     private fun getFailedDetails() =
@@ -89,6 +90,10 @@ internal class PaymentResultViewEntityMapper(
             DojoPaymentType.PAYMENT_CARD, DojoPaymentType.VIRTUAL_TERMINAL ->
                 customStringProvider.resultScreenTitleFail ?: stringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_fail)
         }
+    }
+
+    private fun getFailedOrderInfo(): String? {
+        return customStringProvider.resultScreenOrderIdText
     }
 
     private fun getErrorImage() = if (isDarkModeEnabled) {

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/state/PaymentResultState.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/ui/result/state/PaymentResultState.kt
@@ -14,6 +14,7 @@ internal sealed class PaymentResultState(open val appBarTitle: String) {
         val imageId: Int,
         val status: String,
         val details: String,
+        val orderInfo: String? = null,
         val shouldNavigateToPreviousScreen: Boolean,
     ) : PaymentResultState(appBarTitle)
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -30,6 +30,7 @@ import tech.dojo.pay.uisdk.domain.entities.DojoUrls
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentDomainEntity
 import tech.dojo.pay.uisdk.domain.entities.PaymentIntentResult
 import tech.dojo.pay.uisdk.domain.entities.SupportedCountriesDomainEntity
+import tech.dojo.pay.uisdk.presentation.ui.CustomStringProvider
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.entity.SupportedCountriesViewEntity
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.AllowedPaymentMethodsViewEntityMapper
 import tech.dojo.pay.uisdk.presentation.ui.carddetailscheckout.mapper.CardCheckOutFullCardPaymentPayloadMapper
@@ -64,6 +65,7 @@ class CardDetailsCheckoutViewModelTest {
     private val makeCardPaymentUseCase: MakeCardPaymentUseCase = mock()
     private val navigateToCardResult: (dojoPaymentResult: DojoPaymentResult) -> Unit = mock()
     private var isStartDestination: Boolean = false
+    private val customStringProvider: CustomStringProvider = mock()
 
     @Before
     fun setUp() {
@@ -84,6 +86,22 @@ class CardDetailsCheckoutViewModelTest {
             saveCardToolBar,
         )
     }
+
+    private fun buildVm() = CardDetailsCheckoutViewModel(
+        observePaymentIntent,
+        dojoCardPaymentHandler,
+        observePaymentStatus,
+        getSupportedCountriesUseCase,
+        supportedCountriesViewEntityMapper,
+        allowedPaymentMethodsViewEntityMapper,
+        cardCheckoutScreenValidator,
+        cardCheckOutFullCardPaymentPayloadMapper,
+        stringProvider,
+        isStartDestination,
+        makeCardPaymentUseCase,
+        navigateToCardResult,
+        customStringProvider,
+    )
 
     @Test
     fun `when init viewModel with isStartDestination as false should emit correct state`() =
@@ -121,20 +139,7 @@ class CardDetailsCheckoutViewModelTest {
                 actionButtonState = ActionButtonState(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
             // assert
             Assert.assertEquals(expected, viewModel.state.value)
         }
@@ -176,20 +181,7 @@ class CardDetailsCheckoutViewModelTest {
                 actionButtonState = ActionButtonState(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
             // assert
             Assert.assertEquals(expected, viewModel.state.value)
         }
@@ -253,20 +245,7 @@ class CardDetailsCheckoutViewModelTest {
                 urls = DojoUrls.Uk()
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
             // assert
             Assert.assertEquals(expected, viewModel.state.value)
         }
@@ -351,20 +330,7 @@ class CardDetailsCheckoutViewModelTest {
                 urls = DojoUrls.Uk(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
             // assert
             Assert.assertEquals(expected, viewModel.state.value)
         }
@@ -448,20 +414,7 @@ class CardDetailsCheckoutViewModelTest {
                 urls = DojoUrls.Uk(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
             // assert
             Assert.assertEquals(expected, viewModel.state.value)
         }
@@ -547,20 +500,7 @@ class CardDetailsCheckoutViewModelTest {
                 urls = DojoUrls.Uk(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
 
             viewModel.onCardHolderValueChanged("new")
             // assert
@@ -646,20 +586,7 @@ class CardDetailsCheckoutViewModelTest {
                 urls = DojoUrls.Uk(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
             viewModel.onCardNumberValueChanged("new")
             viewModel.onCvvValueChanged("new")
             viewModel.onExpireDateValueChanged("new")
@@ -747,20 +674,8 @@ class CardDetailsCheckoutViewModelTest {
                 urls = DojoUrls.Uk(),
             )
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
+
             viewModel.onEmailValueChanged("new")
             // assert
             Assert.assertEquals(expected, viewModel.state.value)
@@ -804,20 +719,8 @@ class CardDetailsCheckoutViewModelTest {
             )
             given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
+
             viewModel.validateCardHolder("new")
             viewModel.validateCardNumber("new")
             viewModel.validateExpireDate("new")
@@ -884,20 +787,8 @@ class CardDetailsCheckoutViewModelTest {
             )
             given(allowedPaymentMethodsViewEntityMapper.apply(any())).willReturn(supportedIcons)
             // act
-            val viewModel = CardDetailsCheckoutViewModel(
-                observePaymentIntent,
-                dojoCardPaymentHandler,
-                observePaymentStatus,
-                getSupportedCountriesUseCase,
-                supportedCountriesViewEntityMapper,
-                allowedPaymentMethodsViewEntityMapper,
-                cardCheckoutScreenValidator,
-                cardCheckOutFullCardPaymentPayloadMapper,
-                stringProvider,
-                isStartDestination,
-                makeCardPaymentUseCase,
-                navigateToCardResult,
-            )
+            val viewModel = buildVm()
+
             viewModel.onPayWithCardClicked()
             // assert
             verify(makeCardPaymentUseCase).makeCardPayment(any(), any())

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/carddetailscheckout/viewmodel/CardDetailsCheckoutViewModelTest.kt
@@ -145,6 +145,24 @@ class CardDetailsCheckoutViewModelTest {
         }
 
     @Test
+    fun `when init viewModel with custom title should emit correct title`() =
+        runTest {
+            // arrange
+            val expectedTitle = "customTitle"
+            given(customStringProvider.cardDetailsNavigationTitle).willReturn(expectedTitle)
+
+            val paymentIntentFakeFlow: MutableStateFlow<PaymentIntentResult> = MutableStateFlow(PaymentIntentResult.None)
+            given(observePaymentIntent.observePaymentIntent()).willReturn(paymentIntentFakeFlow)
+            val paymentStateFakeFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
+            given(observePaymentStatus.observePaymentStates()).willReturn(paymentStateFakeFlow)
+
+            // act
+            val viewModel = buildVm()
+            // assert
+            Assert.assertEquals(expectedTitle, viewModel.state.value?.toolbarTitle)
+        }
+
+    @Test
     fun `when init viewModel with isStartDestination as true should emit correct state with full loading as true  and correct toolBar title `() =
         runTest {
             // arrange

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
@@ -48,6 +48,56 @@ class PaymentResultViewEntityMapperTest {
     }
 
     @Test
+    fun `when calling mapTpResultState with successful result with for PAYMENT_CARD and custom fields should return successfulResult with correct fields`() {
+        // arrange
+        given(customStringProvider.resultScreenTitleSuccess).willReturn("Title Successful Payment")
+        given(customStringProvider.resultScreenMainTextSuccess).willReturn("Successful Payment")
+        given(customStringProvider.resultScreenAdditionalTextSuccess).willReturn("Successful Payment Add")
+
+        val expected = PaymentResultState.SuccessfulResult(
+            appBarTitle = "Title Successful Payment",
+            imageId = 2131230888,
+            status = "Successful Payment",
+            orderInfo = "",
+            description = "Successful Payment Add",
+        )
+
+        // act
+        mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
+        val result = mapper.mapTpResultState(DojoPaymentResult.SUCCESSFUL)
+
+        // Assert
+        assert(result is PaymentResultState.SuccessfulResult)
+        val actual = result as PaymentResultState.SuccessfulResult
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `when calling mapTpResultState with fail result with for PAYMENT_CARD and custom fields should return failResult with correct fields`() {
+        // arrange
+        given(customStringProvider.resultScreenTitleFail).willReturn("Title fail Payment")
+        given(customStringProvider.resultScreenMainTextFail).willReturn("fail Payment")
+        given(customStringProvider.resultScreenAdditionalTextFail).willReturn("fail Payment Add")
+
+        val expected = PaymentResultState.FailedResult(
+            appBarTitle = "Title fail Payment",
+            imageId = R.drawable.ic_error_circle,
+            status = "fail Payment",
+            details = "fail Payment Add",
+            shouldNavigateToPreviousScreen = false,
+        )
+
+        // act
+        mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
+        val result = mapper.mapTpResultState(DojoPaymentResult.FAILED)
+
+        // Assert
+        assert(result is PaymentResultState.FailedResult)
+        val actual = result as PaymentResultState.FailedResult
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
     fun `when calling mapTpResultState with successful result with for SETUP_INTENT payment type should return successfulResult with correct fields`() {
         // arrange
         given(mockStringProvider.getString(R.string.dojo_ui_sdk_payment_result_main_title_setup_intent_success))
@@ -137,6 +187,18 @@ class PaymentResultViewEntityMapperTest {
         // act
         mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
         val mappedOrderId = mapper.mapToOrderIdField(orderId)
+        Assert.assertEquals(expectedResult, mappedOrderId)
+    }
+
+    @Test
+    fun `when calling mapToOrderIdField with custom should return custom `() {
+        // arrange
+        val expectedResult = "Order ID: franco.manca.123456"
+        given(customStringProvider.resultScreenOrderIdText).willReturn(expectedResult)
+
+        // act
+        mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
+        val mappedOrderId = mapper.mapToOrderIdField(orderId = "123456")
         Assert.assertEquals(expectedResult, mappedOrderId)
     }
 }

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
@@ -125,18 +125,21 @@ class PaymentResultViewEntityMapperTest {
     @Test
     fun `when calling mapTpResultState with FAILED result with for SETUP_INTENT payment type should return FailedResult with correct fields`() {
         // arrange
+        val orderId = "orderId-custom"
         given(mockStringProvider.getString(R.string.dojo_ui_sdk_payment_result_main_message_setup_intent_fail))
             .willReturn("Failed Setup Intent")
         given(mockStringProvider.getString(R.string.dojo_ui_sdk_payment_result_main_title_setup_intent_fail))
             .willReturn("Failed Setup Intent")
         given(mockStringProvider.getString(R.string.dojo_ui_sdk_payment_result_title_setup_intent_fail))
             .willReturn("Failed Setup Intent")
+        given(customStringProvider.resultScreenOrderIdText).willReturn(orderId)
         val expected = PaymentResultState.FailedResult(
             appBarTitle = "Failed Setup Intent",
             imageId = 2131230871,
             status = "Failed Setup Intent",
             details = "Failed Setup Intent",
             shouldNavigateToPreviousScreen = false,
+            orderInfo = orderId
         )
 
         // act

--- a/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
+++ b/uisdk/src/test/java/tech/dojo/pay/uisdk/presentation/ui/result/mapper/PaymentResultViewEntityMapperTest.kt
@@ -8,12 +8,21 @@ import tech.dojo.pay.sdk.DojoPaymentResult
 import tech.dojo.pay.uisdk.R
 import tech.dojo.pay.uisdk.core.StringProvider
 import tech.dojo.pay.uisdk.entities.DojoPaymentType
+import tech.dojo.pay.uisdk.presentation.ui.CustomStringProvider
 import tech.dojo.pay.uisdk.presentation.ui.result.state.PaymentResultState
 
 class PaymentResultViewEntityMapperTest {
 
     private var mockStringProvider: StringProvider = mock()
+    private val customStringProvider: CustomStringProvider = mock()
     private lateinit var mapper: PaymentResultViewEntityMapper
+
+    private fun buildMapper(type: DojoPaymentType) = PaymentResultViewEntityMapper(
+        stringProvider = mockStringProvider,
+        paymentType = type,
+        isDarkModeEnabled = false,
+        customStringProvider = customStringProvider
+    )
 
     @Test
     fun `when calling mapTpResultState with successful result with for PAYMENT_CARD payment type should return successfulResult with correct fields`() {
@@ -29,11 +38,7 @@ class PaymentResultViewEntityMapperTest {
         )
 
         // act
-        mapper = PaymentResultViewEntityMapper(
-            stringProvider = mockStringProvider,
-            paymentType = DojoPaymentType.PAYMENT_CARD,
-            isDarkModeEnabled = false,
-        )
+        mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
         val result = mapper.mapTpResultState(DojoPaymentResult.SUCCESSFUL)
 
         // Assert
@@ -58,11 +63,7 @@ class PaymentResultViewEntityMapperTest {
         )
 
         // act
-        mapper = PaymentResultViewEntityMapper(
-            stringProvider = mockStringProvider,
-            paymentType = DojoPaymentType.SETUP_INTENT,
-            isDarkModeEnabled = false,
-        )
+        mapper = buildMapper(type = DojoPaymentType.SETUP_INTENT)
         val result = mapper.mapTpResultState(DojoPaymentResult.SUCCESSFUL)
 
         // Assert
@@ -89,11 +90,7 @@ class PaymentResultViewEntityMapperTest {
         )
 
         // act
-        mapper = PaymentResultViewEntityMapper(
-            stringProvider = mockStringProvider,
-            paymentType = DojoPaymentType.SETUP_INTENT,
-            isDarkModeEnabled = false,
-        )
+        mapper = buildMapper(type = DojoPaymentType.SETUP_INTENT)
         val result = mapper.mapTpResultState(DojoPaymentResult.FAILED)
 
         // Assert
@@ -120,11 +117,7 @@ class PaymentResultViewEntityMapperTest {
         )
 
         // act
-        mapper = PaymentResultViewEntityMapper(
-            stringProvider = mockStringProvider,
-            paymentType = DojoPaymentType.PAYMENT_CARD,
-            isDarkModeEnabled = false,
-        )
+        mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
         val result = mapper.mapTpResultState(DojoPaymentResult.FAILED)
 
         // Assert
@@ -142,11 +135,7 @@ class PaymentResultViewEntityMapperTest {
         val orderId = "123456"
         val expectedResult = "Order ID: 123456"
         // act
-        mapper = PaymentResultViewEntityMapper(
-            stringProvider = mockStringProvider,
-            paymentType = DojoPaymentType.PAYMENT_CARD,
-            isDarkModeEnabled = false,
-        )
+        mapper = buildMapper(type = DojoPaymentType.PAYMENT_CARD)
         val mappedOrderId = mapper.mapToOrderIdField(orderId)
         Assert.assertEquals(expectedResult, mappedOrderId)
     }


### PR DESCRIPTION
###MPP-1655

Custom copy for card details title and payment result.

- DojoThemeSettings: new prop to allow custom strings for ui strings. 
- CustomStringProvider: custom strings provider.
- CardDetailsCheckoutViewModel: used CustomStringProvider to provide custom title. 
- PaymentResultViewEntityMapper: used CustomStringProvider to provide custom values on fail/success. 
- Introduced serializableCompat to replaced the deprecated usages. 
- fixed tests

<img width="300" alt="Screenshot 2024-10-28 at 16 26 52" src="https://github.com/user-attachments/assets/0dcf2c36-f294-473b-a77b-6c23c32fc2c6">

<img width="300" alt="Screenshot 2024-10-28 at 16 26 46" src="https://github.com/user-attachments/assets/fc7dabc1-11da-4ecc-aead-ce681f04ff0d">

