### PR TITLE
Standalone Security Scanning workflow

### DIFF
--- a/.github/workflows/standalone-security-scans.yml
+++ b/.github/workflows/standalone-security-scans.yml
@@ -1,0 +1,15 @@
+name: Security Scans
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main,  master ]
+jobs:
+  security-scans:
+    uses: dojo-engineering/github-workflows/.github/workflows/security-scans.yml@main
+    secrets: inherit
+    with:
+      # wiz-dir-policy-name: ${{ vars.WIZ_POLICY_DIR_PCI }} # uncomment for PCI projects
+      # wiz-iac-policy-name: ${{ vars.WIZ_POLICY_IAC_PCI }} # uncomment for PCI projects
+      wiz-project-uuid: ${{ vars.WIZ_PROJECT_UUID_PAYMENTS_PRODUCTS }}


### PR DESCRIPTION
# Standalone Security Scans

This change aims to help Dojo shifting security left by providing engineers with little to no configuration scans for SCA (Software Composition Analysis), Iac (Infrastructure as Code) and leaked secrets. To achieve that, we are relying on a tool called Wiz CLI that will run in parallel to the workflows already being run in the repository.

Please visit our notion page for more information on the [Standalone Security Scans](https://www.notion.so/dojo-/Standalone-Security-Scans-240f4f4905684d61891f5251dbb0e5b7) project or if you have any questions about the [Application Security Tooling](https://www.notion.so/dojo-/Application-Security-Tooling-39d3bec05f884224af0ef0bec566f571) and what they do.

Have any questions? Please reach out to us on [#application-security-tools](https://dojo.slack.com/archives/C05MU7KL3QS) on Slack.

# What else needs to be done (by you)

- Update wiz-project-uuid on `standalone-security-scans.yml` with what's relevant to your tribe;
- If on PCI projects, uncomment the lines related to the policies;
- Remove anything related to Snyk SCA or IaC from your repos;
- Replace (or add) Snyk container scan with Wiz container scan;
- (if on reusable workflows) Update variables on reusable workflows;
- Merge the PR;

## Updating wiz-project-uuid

The first thing that needs to be done is to update the `project-uuid` attribute and replace the `WIZ_PROJECT_UUID_REPLACE_ME` with a value that matches your tribe. To list the available project uuids, on your repo, first go to settings -> Secrets and variables -> Actions and then click on the Variables tab. There you can see a variable that will be relevant to your repository. Please reach out to us if you think there's anything missing or if you have any questions.

## Removing any traces of SNYK    

Snyk is being deprecated so we must remove anything related to it, plain and simple. Since the Standalone Security Scans already provide SCA, IaC and Secret scanning, you can simply remove those from your workflows. Container scanning will be replaced with Wiz container scanning (more details on the next steps).

## Container Scanning

**NOTE: Don't worry about this if you are using the reusable workflows!**

If you are deploying containers and have no container scanning already set up, we strongly suggest you to add it. Here's how the scanning STEP would look like in your workflow. NOTE: It goes without saying that we need the container built and available in the step prior to scanning.

```
  - uses: dojo-engineering/security-actions/scans/wiz-container@main
    with:
      image: your-container-image-goes-here:latest
      # project-uuid: ${{ vars.WIZ_PROJECT_UUID_REPLACE_ME }}
      client-id: ${{ secrets.WIZ_CLIENT_ID }}
      client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}
      # policy-name: ${{ vars.WIZ_POLICY_CONTAINER_PCI }} # uncomment for PCI projects
```

More information [here](https://github.com/dojo-engineering/security-actions/tree/main/scans/wiz-container).

## Updating reusable workflows

The first step is to remove anything related to Snyk from there since snyk is being replaced with Wiz. If you don't have anything, all that's left to do is to pass on the secrets and update the proper variables.

```
  with:
    security-enable: true
  secrets:
    wiz-client-id: ${{ secrets.WIZ_CLIENT_ID }}
    wiz-client-secret: ${{ secrets.WIZ_CLIENT_SECRET }}
    wiz-project-uuid: ${{ secrets.WIZ_PROJECT_UUID_REPLACE_ME }}
```

# What happens next?

Congratulations, you now have Dojo's basic Application Security Tooling running on your repository. From now on, you should see a summary with the scan results posted as a comment on your PR and, if you need more information, you can go to the job itself for a complete list of the issues and a link to them in Wiz.

Of course we don't expect anyone to fix everything in one go, but having a little bit more visibility earlier in the development process helps speeding up these fixes.

[_Created by Sourcegraph batch change `Luis-Almeida/standalone-security-scans-payments-products`._](https://dojo.sourcegraph.com/users/Luis-Almeida/batch-changes/standalone-security-scans-payments-products)