### PR TITLE
MPP-1796: Android 8 issue

### DIFF
--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -140,6 +140,8 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
 
     @SuppressLint("SourceLockedOrientationActivity")
     private fun lockToPortrait() {
+        // had to avoid locking orientation because failing on Android 8 or less.
+        // FullScreen and transparent mode do not allow to force orientation on Android 8 and previous.
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
@@ -139,7 +140,9 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
 
     @SuppressLint("SourceLockedOrientationActivity")
     private fun lockToPortrait() {
-        requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O) {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        }
     }
 
     private fun disableScreenRecord() {


### PR DESCRIPTION
#MPP-1796

With Android 8 and fullscreen mode/transparent is not allowed to request lock on portraid mode. I couldn't find any solution that is actually working on Android 8 and below so I disabled the lock 
