### PR TITLE
MPP-1815: VT payment system bar issue.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -7,7 +7,7 @@ object Sdk {
 }
 
 object Versions {
-    const val ACTIVITY = "1.4.0"
+    const val ACTIVITY = "1.9.3"
     const val FRAGMENT = "1.4.1"
     const val ACTIVITY_COMPOSE = "1.3.0-beta01"
     const val VIEWMODEL_COMPOSE = "1.0.0-alpha04"

--- a/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
+++ b/uisdk/src/main/java/tech/dojo/pay/uisdk/presentation/PaymentFlowContainerActivity.kt
@@ -6,8 +6,10 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.os.Bundle
+import android.view.View
 import android.view.WindowManager
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedVisibility
@@ -22,6 +24,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -87,7 +92,9 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        applyWindowInset(window.decorView)
         disableScreenRecord()
         lockToPortrait()
         configureDojoPayCore()
@@ -514,5 +521,23 @@ class PaymentFlowContainerActivity : AppCompatActivity() {
         data.putExtra(DojoPaymentFlowHandlerResultContract.KEY_RESULT, result)
         setResult(RESULT_OK, data)
         overridePendingTransition(200, R.anim.exit)
+    }
+
+    private fun applyWindowInset(root: View) {
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val bars = insets.getInsets(
+                WindowInsetsCompat.Type.navigationBars()
+                    or WindowInsetsCompat.Type.statusBars()
+                    or WindowInsetsCompat.Type.displayCutout()
+                    or WindowInsetsCompat.Type.ime(),
+            )
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
     }
 }


### PR DESCRIPTION
## MPP-1815

With Andorid 15 all the apps targeting Android 15 and running on Android 15 will have system bar under/above the content.

<img width="200" alt="Screenshot 2024-12-19 at 14 00 01" src="https://github.com/user-attachments/assets/93023c93-0275-4ffc-be47-a870745ce5aa" />

We have to apply some changes to the activity on the sdk to avoid this:

- updated activity dep lib.
- PaymentFlowContainerActivity: applied insets and edge to edge in order to avoid content going above the system bars

<img width="1222" alt="Screenshot 2024-12-19 at 13 56 39" src="https://github.com/user-attachments/assets/ebfdda6a-49a8-4662-be36-7df4d715a012" />

<img width="200" alt="Screenshot 2024-12-19 at 14 28 59" src="https://github.com/user-attachments/assets/563b81da-e396-4cc8-a6ae-78248df8f566" />

